### PR TITLE
visual cues for offensive ranges, 151FTL and RBA guides/resources

### DIFF
--- a/docs/gen-1/red-blue/catext/catch-em-all-classic/README.md
+++ b/docs/gen-1/red-blue/catext/catch-em-all-classic/README.md
@@ -1,0 +1,192 @@
+# Pokemon Blue Catch 'Em All (Classic) aka 151 FTL
+**CLEAR SAVE DATA FOR EACH ATTEMPT OR YOUR RUN IS INVALID**
+
+_TODO_ is this route possible with PP strat? ask luckytyphlosion
+
+credits to luckytyphlosion for routing this and also writing the original guide https://pastebin.com/c5F57GVX
+
+- manip TID 0x765e (30302)
+ 	- https://youtu.be/jB4u4UU4gyU
+- name player baaaa
+- name rival ??//;;
+	- note: input rival name to 7 characters, then delete last char to get proper rival name to save a bit on tossing ethers
+	- i.e. input rival name to be ??//;;;, then press B to make rival name ??//;;
+
+The first glitch we will perform is called Brock Through Walls.
+A detailed guide on what strategy could be best for you and how to execute it can be found here _TODO_ add link to docs/gen-1/red-blue/catext/catch-em-all-classic/resources/Brock-Through-Walls_Guide.md
+
+- **[PP/Pidgey Strat]** Viridian shop: buy
+	- 10 Pokeballs
+- pick up forest antidote
+- pick up forest potion
+- win weedle fight
+- **[PP/Pidgey Strat]** shop: buy
+  - 1escape rope  
+  - 1 parlyz heal
+  - 1 burn heal
+  - 1 awakening
+- **[1024 Charmander]** shop: buy
+  - 9 Pokeballs
+    - 10 if you didn't use your antidote
+  - 1 burn heal
+  - 1 escape rope
+  - 1 antidote
+    - skip if you didn't use it
+  - 1 parlyz heal
+- brock through walls as explained in the guide linked above
+- your goal is to reach Mewtwo Cave, the fastest path is shown here:
+	- https://youtu.be/7jT0nZStQNU
+	- take this path carefully: you are walking out of bounds, one false step can crash the game
+- **[1024 Charmander]** ditto manip:
+	- redbar: https://www.youtube.com/watch?v=zofvpQK4dFQ
+	- non redbar: https://www.youtube.com/watch?v=aIE01IgqhFw&list=PLFAPrbMDJZ2LS1c8W46jPxlMB5QQpyKMv&index=4
+- **[PP/Pidgey Strat]** ditto manip:
+ 	- https://youtu.be/alE01lgqhFw
+- swap ditto to front, use escape rope
+- get CoolTrainer glitch:
+	- encounter any Rattata or a lv5 Pidgey
+	- in the encounter, use trasform, then swap your moves order and run away
+- pokedex menu flash on grass tile next to side of ledge: https://i.imgur.com/Bbh6R3V.png
+	- can do this before getting CoolTrainerT, as long as you do not open any submenu
+- double distort missingno:
+	- view CoolTrainer until corruption
+	- flash item menu
+	- view CoolTrainerT again until another corruption
+	- do this fast enough and get first ball missingno to skip missingno cry
+	- you can also view CoolTrainerT again if audio completely fades out and you haven't caught missingno by then for another chance at skipping missingno's cry
+- toss awakening x2, double distort again (no need to worry about missingno cry this time)
+- walk to this location: https://i.imgur.com/UjbIja3.png
+- swap ditto with rhydon
+- swap antidote x1 (third) with awakening x255 (6th) (if used all poke balls, reference item slots)
+- toss antidote x1 (6th)
+- dry underflow
+- do not flash use/toss or back out/enter in to save a bit of frames (maybe)
+- swap awakening x0 with 9th slot
+- teach missingno teleport (tm30)
+- swap ether x80 into options
+- swap xblock master ball x0 with potion x0
+- toss 240 from potion x0 to get 16
+- swap potion x16 with RED in text pointer
+- save
+- take one step left
+- view trainer card
+- swap bicycle (up 5) with ultra ball (up 3)
+- swap bicycle with Q r 4 h I
+- get on and off the bicycle
+- the game should crash. hard reset
+- open inventory
+- toss 1 from awakening in 9th slot
+- toss all of tm55 in 8th slot (quantity 0), 7th slot (x1), 6th slot (x0 if had poke balls left, x1 if ran out of poke balls), 5th slot (x1) (BUT NOT 4TH!)
+- walk down 1 and right 1, then press A to access the player PC
+- open deposit menu
+- if got PC potion: deposit []j. x1
+- deposit tm55 in fourth slot
+- deposit awakening x255
+- go to toss menu
+- toss CANCEL under potion/[]j. x1
+- toss potion x1
+- dry underflow
+- toss []j. from 5th slot in box underflow
+	- alternatively, back out and in of toss menu
+	- swap 5th []j. with 6th []j.
+- walk down to grass and get an encounter
+- use 9F in TID, then use teleport with missingno (cannot just walk back to daisy's house)
+- walk to daisy's house
+- walk right 1 to save []j. lag
+- toss 253 master balls from warping to get to 3
+- exit daisy's house
+- enter cerulean house
+- swap []j. x3 with ultra ball x1
+- scroll to tm22 x65, toss 58 to get to 7
+- swap tm22 x7 with ultra ball x1
+- swap []j. x255 in connections byte with tmtrainer item below
+- swap []j. x255 with coin case directly under the first cancel button you see (swap while cancel button is on screen to save frames)
+- swap []j. x255 with ultra ball x1 OR great ball x1 directly under cancel
+	- swapping with great ball x1 saves []j. frames
+- toss []j. x175 from []j. x255 to get []j. x80
+- exit house
+- open item menu
+- scroll up until you see fire stone x[]9 (close to poké flute, above marshbadge)
+- press select on fire stone x[]9
+- scroll up until you hit a click item
+- press b three times to advance click item, then immediately press select
+- swap fire stone x[]9 with x accuracy x90
+- swap fire stone x[]9 with []4   [] "
+- toss 119 from dire hit x126 to get 7
+- scroll up, swap ether x80 in options with []4   [] "
+- toss 29 from ether x80 to get 51
+- bonk right, talk to invisible sign which is now a mart
+- NOTE: selling items with OWRB skips sell jingle, be sure to sell fast!
+- sell: []j. x0/x255, parlyz heal x1, burn heal x1, 7 stacks of awakening x255 (money should be 678789)
+- buy (IN ORDER): hyper potion x99, hyper potion x99, hyper potion x20, rare candy x1
+	- buy rare candy x81 if you want to preserve save file after credits
+- exit mart
+- open item menu
+- swap tm43 x243 in rival name with ether x51 in text pointer
+- toss 227 from tm43 x243 to get 16
+- scroll down, select repel x241 near super rod
+- scroll down until you hit a click item
+- 3 clicks twice, then press select on click item to swap with repel x241
+	- if you accidentally deselect the repels, advance past the click item and select the repel x248 near poke flute
+- press select on repel and scroll down again until you hit another click item
+- 1 click 4 times to advance through
+- scroll down again until you see rare candy x1
+- scroll a bit more until the cursor is on cancel below rare candy x1 (reduces []j. lag)
+- swap repels with []j. x0 above rare candy x1
+- toss repels to get to repel x190 (241 tosses 51, 248 tosses 58)
+- exit menu, press A to talk to invisible prize vendor
+- NOTE: can use repels multiple times instead of tossing (not sure on which is faster)
+- by default, a repel is used each time per pokemon
+- no need to change box since party count is set to 0 every time you talk to the prize vendor
+
+## Farm
+- buy a Pokemon from the middle slot, use 1 Repel and repeat, unless the table below says otherwise
+	- 2- repels: using is faster
+	- 3+ repels: tossing is faster
+- buy tangela and chansey from 1st and 3rd slot respectively at some point
+
+| after [Pokemon], use/toss [x] Repels | PP Strat  | Pidgey Strat | 1024 Charmander |
+| ---------- | --------- | ------------ | --------------- |
+| Oddish 		 | 5 				 | 5 				 		| 5								|
+| Squirtle	 |					 |					 		| 4								|
+| Charmander | 3 				 | 3 				 		|					  			|					
+| Magnemite  | 3 				 | 2 				 		| 2								|
+| Ponyta 		 | 5 				 | 5 				 		| 5								|
+| Goldeen 	 | 2 				 | 2 				 		| 2								|
+| Venusaur 	 | 2 				 | 2 				 		|									|
+| Haunter 	 | 2 				 | 2 				 		| 2								|
+| Electrode  | 2 				 | 2 				 		| 2								|
+| Kingler 	 | 2 				 | 2 				 		| 2								|
+| Muk 			 | 3 				 | 3 				 		| 3								|
+| Golduck 	 | 2 				 | 2 				 		| 2								|
+| Caterpie 	 | 3 				 | 3 				 		| 3								|
+| Dodrio 		 | 2 				 | 2 				 		| 2								|
+| Sandshrew  | 3 				 | 3 				 		| 3								|
+| Dratini 	 | 3 				 | 3 				 		| 3								|
+| Vulpix 		 | 4 				 | 4 				 		| 4								|
+| Meowth 		 | 2 				 | 2 				 		| 2								|
+| Doduo 		 | 4 				 | 4 				 		| 4								|
+| Farfetch’d | 4 				 | 4 				 		| 4								|
+| Mankey 		 | 2 				 | 2 				 		| 2								|
+| Electabuzz | 2 				 | 2 				 		| 2								|
+| Magmar 		 | 2 				 | 2 				 		| 2								|
+| Machoke 	 | 2 				 | 2 				 		| 2								|
+| Slowpoke 	 |  				 | 2 				 		|									|
+| Growlithe  | 4 				 | 4 				 		| 4								|
+
+**Stop after buying Kangashkan**
+
+- once all pokemon have been bought, toss 0 from []j. x0 directly under cancel button
+- OPTIONAL SAVE FILE PRESERVATION STRAT:
+	- do this before getting kangashkan, and do not do []j. x0 toss yet:
+	- toss 1 from rare candy x81 to get rare candy x80
+	- press select on rare candy x80
+	- scroll down until inventory wraps around, then scroll up until the first occurance when []j.s appear
+	- press up once more, then press select to swap rare candy x80
+	- exit menu and get kangaskhan
+	- toss 0 from []j. x0 below rare candy x80
+- press select on []j. x0 directly below last awakening x255 stack (saves []j. frames getting the []j. x0 here)
+- scroll down and press select on dire hit x7
+- scroll up a bit and press select on master ball x118
+- press select on ????? above coin case
+- exit menu and walk up to HoF

--- a/docs/gen-1/red-blue/catext/catch-em-all-classic/README.md
+++ b/docs/gen-1/red-blue/catext/catch-em-all-classic/README.md
@@ -1,9 +1,11 @@
 # Pokemon Blue Catch 'Em All (Classic) aka 151 FTL
 **CLEAR SAVE DATA FOR EACH ATTEMPT OR YOUR RUN IS INVALID**
 
-_TODO_ is this route possible with PP strat? ask luckytyphlosion
-
 credits to luckytyphlosion for routing this and also writing the original guide https://pastebin.com/c5F57GVX
+
+If something isn't clear,you should watch:
+  - **[1024 Charmander]** stocchi's run
+  - **[PP/Pidgey Strat]** krazyd4n's run
 
 - manip TID 0x765e (30302)
  	- https://youtu.be/jB4u4UU4gyU

--- a/docs/gen-1/red-blue/catext/catch-em-all-classic/resources/1024-charmander-manip
+++ b/docs/gen-1/red-blue/catext/catch-em-all-classic/resources/1024-charmander-manip
@@ -1,0 +1,1 @@
+speedrun-routes\docs\gen-1\red-blue\catext\reverse-badge-acquisition\resources\1024-charmander-manip.md

--- a/docs/gen-1/red-blue/catext/catch-em-all-classic/resources/Brock-Through-Walls_Guide
+++ b/docs/gen-1/red-blue/catext/catch-em-all-classic/resources/Brock-Through-Walls_Guide
@@ -1,0 +1,1 @@
+docs\gen-1\red-blue\catext\reverse-badge-acquisition\resources\Brock-Through-Walls-Guide.md

--- a/docs/gen-1/red-blue/catext/reverse-badge-acquisition/README.md
+++ b/docs/gen-1/red-blue/catext/reverse-badge-acquisition/README.md
@@ -1,0 +1,126 @@
+# Pokemon Blue Reverse Badge Acquisition aka Reverse Badge Order
+**CLEAR SAVE DATA FOR EACH ATTEMPT OR YOUR RUN IS INVALID**
+
+If something isn't clear,you should watch:
+  - **[1024 Charmander]** stocchi's run
+  - **[PP/Pidgey Strat]** Araya's run
+
+- manip TID b307 (45831)
+  - https://youtu.be/iH0kW5fd6XA
+- name player uuAAA
+- name rival RRRGpg-
+
+The first glitch we will perform is called Brock Through Walls.
+A detailed guide on what strategy could be best for you and how to execute it can be found here _TODO_ add link to docs/gen-1/red-blue/catext/catch-em-all-classic/resources/Brock-Through-Walls_Guide.md
+- **[1024 Charmander]** route 1 to weedle manip: https://www.youtube.com/watch?v=ZbAv0m19v9g
+- **[PP/Pidgey Strat]** Viridian shop: buy
+  - 9 Pokeballs
+- pick up forest antidote
+- pick up forest potion
+- win weedle fight
+- **[PP/Pidgey Strat]** shop: buy
+  - 1 burn heal
+  - 1 escape rope
+  - 1 awakening
+  - 1 paralyze
+grab antidote on way through forest
+- **[1024 Charmander]** shopping: buy
+  - 7 balls
+  - 1 rope
+  - 1 antidote
+    - skip if you didn't use it
+  - 1 potion
+  - 1 burn heal
+  - 1 awakening
+  - 1 para heal
+- brock through walls as explained in the guide linked above
+- your goal is to reach Mewtwo Cave, the fastest path is shown here:
+  - https://youtu.be/7jT0nZStQNU
+  - take this path carefully: you are walking out of bounds, one false step can crash the game
+- **[1024 Charmander]** ditto manip:
+  - redbar: https://www.youtube.com/watch?v=zofvpQK4dFQ
+  - non redbar: https://www.youtube.com/watch?v=aIE01IgqhFw&list=PLFAPrbMDJZ2LS1c8W46jPxlMB5QQpyKMv&index=4
+- **[PP/Pidgey Strat]** ditto manip:
+   - https://youtu.be/alE01lgqhFw
+- swap ditto to front, use escape rope
+- get CoolTrainer glitch:
+  - encounter any Rattata or a lv5 Pidgey
+  - in the encounter, use trasform, then swap your moves order and run away
+-catch missingno. (1 tile left from NSC)
+-toss 2 para heal
+-catch missingno.
+-underflow
+-swap slot 2 with ID balls, toss 1 from options
+-catch Charizard (Same tile as NSC)
+-walk to bottom row of grass, 2nd tile from left
+-swap Charizard to front
+-toss top item
+-toss 2nd item 6 times (so never the masterballs)
+-swap 3rd para heal with top CANCEL
+-Toss 14 from TM27
+-swap j below TM27 with ultra ball
+-swap hm04 with masterball x0
+-swap TM52 with burn heal
+-toss 19 TMs
+-swap j with hp up
+-toss 8 j
+-step up, face down and fight gio
+-swap flamethrower to 1, flamethrower x5
+-2 with (max) elixir in money,
+-GARY with brightness balls, then j 255
+-swap TM37 with TM27
+-close menu, talk to Gio
+-Deposit all but zard
+-open menu, swap para heal stack above cancel with HM05
+-walk down then up
+-toss all but 3 from TM01
+-swap TM47 below with brightness balls
+-fight Blaine
+-flamethrower x3, slash
+-Swap master ball for TM01
+-Hm04 2 below for potion
+-toss 15 potions
+-toss all but 5 ultra ball above
+-swap master ball above for j 255
+-swap TM32 for []G[], toss all but 4
+-swap moon stone below for j, toss all but 7
+-walk up 2, down 1, face up to fight sabrina
+-flamethrower x4
+-hold down
+-(max) elixir, jack to koga, fight from the bottom
+-flamethrower x4
+-swap slot 4 to money, toss all but 5
+-swap CANCEL to HM04, then brightness, then j
+-step up
+-toss 2 from j x7 above potion
+-swap antidote with poke ball
+-toss all but 4 moon stone
+-fight erika
+-flamethrower x3
+-walk down
+-swap elixir with soda pop in money
+-surf to gym
+-walk up 1
+-swap ultra ball with hm04
+-toss 5 from 7f
+-toss pokeball to 3
+-toss 2 j.
+-walk down, face right for surge
+-flamethrower x3
+-walk down, right 1 tile, then down until you leave the gym
+-Enter gym
+-CANCEL round the left side of the gym to reach Misty
+-Talk to Misty.
+-flamethrower x2 (Rage Starmie if elixir)
+-Swap Soda pop with master ball x3
+-Swap Great ball x0 with HM04 above
+-Swap [block]m[block] x72 below ????? with j. x255
+-Toss 18 from [block]m[block]
+-Close menu, walk up 1
+-Swap ????? above 3f with [block]g[block]
+-Swap Potion x7 with HM05, toss 6 potions
+-Scroll up 1, toss all but 1
+-Walk 2 left, talk to Brock
+-Flamethrower x2
+-Walk straight down to exit the Gym to the Hall of Fame.
+-Timing stops on the fade to white after you receive your in game time.

--- a/docs/gen-1/red-blue/catext/reverse-badge-acquisition/README.md
+++ b/docs/gen-1/red-blue/catext/reverse-badge-acquisition/README.md
@@ -46,81 +46,81 @@ grab antidote on way through forest
 - get CoolTrainer glitch:
   - encounter any Rattata or a lv5 Pidgey
   - in the encounter, use trasform, then swap your moves order and run away
--catch missingno. (1 tile left from NSC)
--toss 2 para heal
--catch missingno.
--underflow
--swap slot 2 with ID balls, toss 1 from options
--catch Charizard (Same tile as NSC)
--walk to bottom row of grass, 2nd tile from left
--swap Charizard to front
--toss top item
--toss 2nd item 6 times (so never the masterballs)
--swap 3rd para heal with top CANCEL
--Toss 14 from TM27
--swap j below TM27 with ultra ball
--swap hm04 with masterball x0
--swap TM52 with burn heal
--toss 19 TMs
--swap j with hp up
--toss 8 j
--step up, face down and fight gio
--swap flamethrower to 1, flamethrower x5
--2 with (max) elixir in money,
--GARY with brightness balls, then j 255
--swap TM37 with TM27
--close menu, talk to Gio
--Deposit all but zard
--open menu, swap para heal stack above cancel with HM05
--walk down then up
--toss all but 3 from TM01
--swap TM47 below with brightness balls
--fight Blaine
--flamethrower x3, slash
--Swap master ball for TM01
--Hm04 2 below for potion
--toss 15 potions
--toss all but 5 ultra ball above
--swap master ball above for j 255
--swap TM32 for []G[], toss all but 4
--swap moon stone below for j, toss all but 7
--walk up 2, down 1, face up to fight sabrina
--flamethrower x4
--hold down
--(max) elixir, jack to koga, fight from the bottom
--flamethrower x4
--swap slot 4 to money, toss all but 5
--swap CANCEL to HM04, then brightness, then j
--step up
--toss 2 from j x7 above potion
--swap antidote with poke ball
--toss all but 4 moon stone
--fight erika
--flamethrower x3
--walk down
--swap elixir with soda pop in money
--surf to gym
--walk up 1
--swap ultra ball with hm04
--toss 5 from 7f
--toss pokeball to 3
--toss 2 j.
--walk down, face right for surge
--flamethrower x3
--walk down, right 1 tile, then down until you leave the gym
--Enter gym
--CANCEL round the left side of the gym to reach Misty
--Talk to Misty.
--flamethrower x2 (Rage Starmie if elixir)
--Swap Soda pop with master ball x3
--Swap Great ball x0 with HM04 above
--Swap [block]m[block] x72 below ????? with j. x255
--Toss 18 from [block]m[block]
--Close menu, walk up 1
--Swap ????? above 3f with [block]g[block]
--Swap Potion x7 with HM05, toss 6 potions
--Scroll up 1, toss all but 1
--Walk 2 left, talk to Brock
--Flamethrower x2
--Walk straight down to exit the Gym to the Hall of Fame.
--Timing stops on the fade to white after you receive your in game time.
+- catch missingno. (1 tile left from NSC)
+- toss 2 para heal
+- catch missingno.
+- underflow
+- swap slot 2 with ID balls, toss 1 from options
+- catch Charizard (Same tile as NSC)
+- walk to bottom row of grass, 2nd tile from left
+- swap Charizard to front
+- toss top item
+- toss 2nd item 6 times (so never the masterballs)
+- swap 3rd para heal with top CANCEL
+- Toss 14 from TM27
+- swap j below TM27 with ultra ball
+- swap hm04 with masterball x0
+- swap TM52 with burn heal
+- toss 19 TMs
+- swap j with hp up
+- toss 8 j
+- step up, face down and fight gio
+- swap flamethrower to 1, flamethrower x5
+- 2 with (max) elixir in money,
+- GARY with brightness balls, then j 255
+- swap TM37 with TM27
+- close menu, talk to Gio
+- Deposit all but zard
+- open menu, swap para heal stack above cancel with HM05
+- walk down then up
+- toss all but 3 from TM01
+- swap TM47 below with brightness balls
+- fight Blaine
+- flamethrower x3, slash
+- Swap master ball for TM01
+- Hm04 2 below for potion
+- toss 15 potions
+- toss all but 5 ultra ball above
+- swap master ball above for j 255
+- swap TM32 for []G[], toss all but 4
+- swap moon stone below for j, toss all but 7
+- walk up 2, down 1, face up to fight sabrina
+- flamethrower x4
+- hold down
+- (max) elixir, jack to koga, fight from the bottom
+- flamethrower x4
+- swap slot 4 to money, toss all but 5
+- swap CANCEL to HM04, then brightness, then j
+- step up
+- toss 2 from j x7 above potion
+- swap antidote with poke ball
+- toss all but 4 moon stone
+- fight erika
+- flamethrower x3
+- walk down
+- swap elixir with soda pop in money
+- surf to gym
+- walk up 1
+- swap ultra ball with hm04
+- toss 5 from 7f
+- toss pokeball to 3
+- toss 2 j.
+- walk down, face right for surge
+- flamethrower x3
+- walk down, right 1 tile, then down until you leave the gym
+- Enter gym
+- CANCEL round the left side of the gym to reach Misty
+- Talk to Misty.
+- flamethrower x2 (Rage Starmie if elixir)
+- Swap Soda pop with master ball x3
+- Swap Great ball x0 with HM04 above
+- Swap [block]m[block] x72 below ????? with j. x255
+- Toss 18 from [block]m[block]
+- Close menu, walk up 1
+- Swap ????? above 3f with [block]g[block]
+- Swap Potion x7 with HM05, toss 6 potions
+- Scroll up 1, toss all but 1
+- Walk 2 left, talk to Brock
+- Flamethrower x2
+- Walk straight down to exit the Gym to the Hall of Fame.
+- Timing stops on the fade to white after you receive your in game time.

--- a/docs/gen-1/red-blue/catext/reverse-badge-acquisition/resources/1024-charmander-manip.md
+++ b/docs/gen-1/red-blue/catext/reverse-badge-acquisition/resources/1024-charmander-manip.md
@@ -1,0 +1,113 @@
+# 1024 Charmander Manipulation
+credits to entrpntr for finding the manipulation and also writing the original notes that you can find here https://pastebin.com/K8TLAKqY
+
+**Disclaimer: The 1024 Charmander Manipulation is one of the most difficult manipulation to successfully pull off in Red/Blue. It is recommended to first start with Bulbasaur to learn the general route.**
+
+For practice/learning, we recommend applying the ISP patch pinned in #rby-category-extension to a copy of your Blue rom to create a practice rom that shows your save frame, Charmander DVs and textbox frames.
+
+## Pre-save
+
+Skip PC Potion
+
+Wait to set options until Charmander save, continue holding B through Pallet Town textboxes.
+
+Recommend starting a timer for 46.45 seconds from when your sprite lands on the bedroom stairs.
+- You will press A to Save when the timer hits 0.00; this is to make sure you save on a good IGT frame.
+This setup should hit in the middle of the cluster of successes from IGT frames 0-22.
+    - Best option: use Flowtimer and add "46450" as an offset. Increase the number of beeps and hit 45450 if you are fast enough by going 2 beeps early
+    - Less precise option: make a split at the stairs and press A when the segment timer is around xx.45
+You can check if you successfully saved on a good frame (0-22) by using the practice rom.
+
+After cutscene textboxes
+  - Move your character below the Charmander ball
+  - Hold UP to sidebonk into the ball; buffer START while still holding UP (this ensures your player will be facing up when reloading save; if you let go of UP before menuing, there is a good chance you'll be facing down upon reload)
+  - Set options (fast text, animations off)
+  - Press A to Save when timer hits 0.00
+
+
+## Post-save
+
+Charmander Manip: https://www.youtube.com/watch?v=PDZyY1w93LA
+  - Can use this working save to practice (Gambatte users: replace existing Blue .sav): https://cdn.discordapp.com/attachments/88133858192551936/326119021768474635/charmander2_blue.sav
+
+You have to hold A or B whenever text is scrolling (wait until jingle starts on "[5 characters name] received a CHARMANDER!" textbox to switch from holding B to A)
+
+Make sure to be on a good frame by using the practice rom or the above save
+
+Start by making sure that you are doing everything up through the naming screen correctly. You can do so in two methods:
+  - Buffering START on the naming screen and checking DVs/stats; if everything else is done correctly, buffering START will yield a Charmander w/DVs = A90A (L5 stats = 19/11/10/11/11).
+  - While using the practice rom you can open your Charmander stats and look at the textboxes numbers. They should be like this :
+    - | Textbox | N.  |
+      | ------- | --- |
+      | TXTBX1  | 229 |
+      | TXTBX2  | 47  |
+      | TXTBX3  | 127 |
+      | TXTBX4  | 58  |
+      | Y/N BX1 | 72  |
+      | Y/N BX2 | 85  |
+
+
+
+Once satisfied that you are executing everything up to the naming screen properly, you can move on to renaming:
+* You need to press A on the naming screen in the first 14 possible frames (sets Charmander's name to 'A'); aim for the early part of this window to be safe
+* To time START perfectly:
+    - You can using game audio cue for when to press START on naming screen (anticipate the loud tone; press start as it is about to play, may need to adjust timing slightly if consistently early/late -- use the list of nearby frames below for calibration)
+    - Set up a flowtimer offset that starts at reset. You can start by using these offsets (_TODO_ add my offsets) but you will need to adjust them to your timings
+
+Approximately 20% chance to get trolled by NPC timers in attempts even if you did everything correctly (the above .sav has good NPC timers, so trolling is not possible if practicing from that)
+
+## How to check success-failure
+
+Once you are confident, skip lv5 stat check and only check in-battle rolls and L6 stats  
+
+| Frame | DVs  | L5 stats       | L6 stats       | L7 stats       |
+| ----- | ---- | -------------- | -------------- | -------------- |
+| 36    | D281 | 19/11/ 9/12/10 |                |                |
+| 37    | 70FB | 20/10/ 9/13/11 |                |                |
+| 38    | E069 | 19/11/ 9/12/10 |                |                |
+| 39    | 80F7 | 19/11/ 9/13/10 |                |                |
+| 40    | 399D | 20/10/10/12/11 | 22/11/11/13/12 |                |
+| 41    | FB4D | 20/11/10/11/11 | 22/13/11/13/12 |                |
+| 42    | D010 | 19/11/ 9/11/10 | 21/12/10/12/11 |                |
+| 43    | 1637 | 20/10/ 9/11/10 | 22/11/11/13/11 |                |
+| 44    | 1024 | 19/10/ 9/11/10 | 21/11/10/13/11 | 23/12/11/14/12 |
+| 45    | 2F29 | 19/10/10/11/10 | 21/11/12/13/12 |                |
+| 46    | F3E9 | 20/11/ 9/12/10 | 22/13/10/14/12 |                |
+| 47    | 3F23 | 20/10/10/11/10 | 22/11/12/13/11 |                |
+| 48    | 6C3F | 19/10/10/11/11 | 21/12/11/13/12 |                |
+| 49    | E5A3 | 19/11/ 9/12/10 |                |                |
+| 50    | 59F5 | 20/10/10/13/10 |                |                |
+| 51    | 39CE | 20/10/10/12/11 |                |                |
+| 52    | 5AE0 | 19/10/10/12/10 |                |                |
+
+
+Check for "good" (i.e. non-working) defense = 3 damage (38/39) at ±0; also takes less damage at -1 thru -4 than "bad" (i.e. working) defense, but same damage ranges as bad defense for crits and stages -5 thru -6.
+
+**Squirtle Tackle damage**
+<table>
+<tr><th>No Growl</th><th>Growl</th></tr><td>
+
+| N. Tail Whips | dmg (roll) | dmg (roll) | dmg (roll) | dmg (roll) |
+| ------------- | ---------- | ---------- | ---------- | ---------- |
+| crit          | 5 (38/39)  | 6 ( 1/39)  |            |            |
+| 0             | 4 (38/39)  | 5 ( 1/39)  |            |            |
+| 1             | 5 ( 2/39)  | 6 (36/39)  | 7 ( 1/39)  |            |
+| 2             | 7 (10/39)  | 8 (28/39)  | 9 ( 1/39)  |            |
+| 3             | 9 (15/39)  | 10 (23/39) | 11 ( 1/39) |            |
+| 4/5/6         | 13 ( 7/39) | 14 (16/39) | 15 (15/39) | 16: (1/39) |
+
+</td><td>
+
+| N. Tail Whips | dmg (roll) | dmg (roll) | dmg (roll) |
+| ------------- | ---------- | ---------- | ---------- |
+| crit          | 5 (38/39)  | 6 ( 1/39)  |            |
+| 0             | 2 (38/39)  | 3 ( 1/39)  |            |
+| 1             | 4 (38/39)  | 5 ( 1/39)  |            |
+| 2             | 5 (38/39)  | 6 ( 1/39)  |            |
+| 3             | 5 ( 2/39)  | 6 (36/39)  | 7  ( 1/39) |
+| 4/5/6         | 8 (13/39)  | 9 (25/39)  | 10 ( 1/39) |
+
+</td></table>
+
+- You can opt to Growl turn 1, which is a guaranteed time loss, but increases chances of winning the fight from ~74.9% to ~91.5%. With Squirtle at -1 atk, you will be able to discern good defense between stages -1 and -4 (but ±0 becomes indistinguishable).
+- Can become less and less cautious with confirming stats the more confident you are with the manip. 19 HP at L5, dealing just 3 damage with Scratch, and receiving expected damage from Squirtle are indicators of the right Charmander.)

--- a/docs/gen-1/red-blue/catext/reverse-badge-acquisition/resources/Brock-Through-Walls-Guide.md
+++ b/docs/gen-1/red-blue/catext/reverse-badge-acquisition/resources/Brock-Through-Walls-Guide.md
@@ -1,0 +1,148 @@
+# Brock Through Walls aka BTW guide
+
+Brock Through Walls is a glitch performed in various red-blue glitched runs.
+It can be done in many ways and everyone of them has it pros and cons.
+This guide is meant to explain what Brock Through Walls strategy you should pick and how to perform it.
+
+_TODO_ technical explanation on how BTW works?
+
+Ranked from fastest to slowest and also from hardest to easiest
+1. 1024 Charmander
+2. Pidgey Strat
+  - with Bulbasaur manipulation
+  - without Bulbasaur manipulation
+3. PP strats
+
+## 1024 Charmander
+This is the hardest but also faster method.
+It requires a 1-frame rename after multiples 4-frames textboxes.
+Because of this, this method should be used only by runners aiming for top times, and only after a lot of practice.
+
+A guide to the manipulation itself can be found here: _TODO_ add link to docs/gen-1/red-blue/catext/reverse-badge-acquisition/resources/1024-charmander-manip.md
+
+After correctly performing it, Weedle fight must be done in specific way to assure correct PP after the fight.
+
+### Weedle guy
+
+Two basic options
+1.  (swap Scratch/Growl), Growl x2, Scratch x7  
+2.   Scratch x6  (only ~5% to kill); if Weedle's still alive:
+    - if 1 Scratch kills (guaranteed to kill if no Gen 1 misses)  ::  (swap Scratch/Growl), Growl x2, Scratch x1
+    - if 1 Scratch doesn't kill (only possible if Gen 1 missed)   ::  Scratch x2
+
+### Fight notes
+1. Safe  (~77.1% to win fight and exit with 38/28 PP)
+    - 2 damage from Poison Sting at -2 (normally does 3 damage)
+    - If you kill Weedle in 6 turns, you will need to burn a Scratch on a wild encounter (and getting encounters is b&)
+    - If you Gen 1 miss and have to use an 8th Scratch to kill, your run is dead (takes too long to get a good PP setup)
+
+2. Risky  (~70.9% to win fight and exit with working PP  ::  ~4.97% for 29/40,  ~64.3% for 38/28,  ~1.69% for 27/40)
+    - Probably only makes sense if grinding for a godly time (more likely to kill run than save time)
+    - Can capitalize on luck if you kill Weedle in 6 turns (~15 seconds saved in fight, 7 seconds lost from Brock skip)
+    - Can usually recover from any Scratch Gen 1 misses
+
+### Brock Skip
+
+If you haven't menued by the time you hit the post-Forest gate (and if you don't need to let poison tick more), menu and put your cursor over SAVE while in the gatehouse (minimal lag + saves a turnframe).
+
+**Brock Skip** _TODO_ what is old brock skip?
+- If 9 turn fight (38 Growl & 28 Scratch), do normal Brock skip (go left; need to hold B while walking)
+- If 6 turn fight (29 Scratch & 40 Growl), do "old" Brock skip (left input is disabled)
+- If 8 turn fight (27 Scratch & 40 Growl), do "old" Brock skip (left input is disabled)
+
+NOTE: 5 turn fight (40 Growl & 30 Scratch) can also do normal Brock skip, but a 5 turn Weedle fight is about a 1 in 2.6 million chance, so it's a TAS-only consideration.
+
+## Pidgey Strat
+This is slower than 1024 Charmander and faster than PP Strat.
+It requires some specific Bulbasaur DVs, so manipulating him can assure these are perfect but even without it the chance are around 65% (_TODO_ check this number) to get a workable Bulbasaur.
+
+### with Bulbasaur Manipulation
+#### 1 second slower manip without IGT tracking
+- https://youtu.be/VjLFyiX5JdA
+- 56/60 manip with perfect attack/special, bad defense
+- textbox stats on practice rom: 231 50 129 55 | 74/81
+
+#### 1 second faster manip with IGT tracking needed
+- Skip PC potion
+-	https://youtu.be/0uN46d8nGHo
+- 38/60 manip with perfect attack/special/defense, saves 93 frames to the 56/60 one
+-	textbox stats on practice rom: 132 207 30 212 | 231/0
+
+Both these manips gets bulba from the bottom, requiring a buffered save. Buffer a flash start, buffer A to talk to the ball, clear every textbox within their 4 frame window while holding A or B, then say no to renaming.
+Both fail 15% of the time because of bad NPC timers
+
+Continue from ###Pidgey _TODO_ make a link
+
+### without Bulbasaur manipulation
+- Pick PC potion
+- Pick Bulbasaur
+- Spam Tackle
+  - Potion if needed (scratch does around 4 [6])
+- On level up, check the special stat value.
+  - 12 Special: Switch to PP strat or reset and try again
+  - 13 Special: Kill one extra encounter. Lv2 Pidgeys or Lv2/3 Rattatas are preferred
+  - 14 Special: Run from anything you see, no extra experience needed
+
+### Pidgey  
+- You will need to catch a Pidgey with the correct HP value _TODO_ correct values. You can either:
+  - Catch a random Pidgey and hope it has good HP
+  - Doing Pidgey manipulation _TODO_ playlist of various pidgey manips
+- After Weedle Guy, check the special stat value again:
+  - 15 Special: Reset or switch to PP STRAT
+  - 16 Special: Continue the run with Pidgey Strat
+
+### Brock Skip:
+  1. Set your cursor over the SAVE option (dont save quite yet)
+  2. Head to Route 3 exit, staying one tile above the sign
+  3. Trigger the cutscene
+  4. When the "Follow Me" textbox appears, clear it with the B button
+  5. **Instantly** after pressing B **hold** the START button
+  6. If you did it right, your start menu should pop up
+  7. Hit SAVE (you are already over it) and soft reset after the game saves
+    - If your start menu didn't open, you hit start too late. Just go back and try again
+  8. Once the game reset, load the savefile normally
+  9. After clearing the last textbox, **hold** RIGHT until you can hear the music change to Route 3 music
+  10. Go back to the guy and stand right next to him
+    - Talk to the guy, after clearing the last textboxes **hold** B and take a couple of steps RIGHT
+    - If the game crashed, your Pidgey had bad HP or your Bulbasaur didn't have 16 Special
+        - If that happens, reset and try again
+
+## PP Strat
+This is the slowest strat but it's also the only one that doesn't require any RNG manipulation and also works 100% of the time.
+We recommend this to anyone who wants to learn/practice the whole run and don't want to reset early game too often.
+- Pick PC potion
+- Pick Bulbasaur
+- Spam Tackle
+  - Potion if needed (scratch does around 4 [6])
+- Run from every encounter, fight Weedle Guy
+- After Weedle Guy, search for encounters in the grass until you find either a Metapod or a Kakuna.
+- Once in the wild encounter battle:
+  - Switch your moves around using the SELECT button until your move order is the following:
+    1. Leech Seed
+    2. Tackle
+    3. Growl
+  - Now, you want to make sure that you setup your PP
+    1. Leech Seed PP doesn't matter
+    2. Growl should have exactly 36PP
+    3. Tacke should have exactly 16PP
+  - If you still need to reach Lv6, also kill the encounter
+    - spam Leech Seed if your PPs are already set
+  - You dont want to reach Lv9, so run away if you are Lv8 the encounter is about to die
+
+### Brock Skip:
+  1. Set your cursor over the SAVE option (dont save quite yet)
+  2. Head to Route 3 exit, staying one tile above the sign
+  3. Trigger the cutscene
+  4. When the "Follow Me" textbox appears, clear it with the B button
+  5. **Instantly** after pressing B **hold** the START button
+  6. If you did it right, your start menu should pop up
+  7. Hit SAVE (you are already over it) and soft reset after the game saves
+    - If your start menu didn't open, you hit start too late. Just go back and try again
+  8. Once the game reset, load the savefile normally
+  9. After clearing the last textbox, **hold** RIGHT until you can hear the music change to Route 3 music
+  10. Go back to the guy and stand right next to him
+    - Open your Pokemon menu
+        - If you have more than 1 pokemon, also swap Bulbasaur to last
+    - Talk to the guy and take a couple of steps RIGHT
+    - If the game crashed, your moves were in the wrong order or your PP's were setup wrong
+        - If that happen, reset and try again

--- a/docs/gen-1/red-blue/main/glitchless/README.md
+++ b/docs/gen-1/red-blue/main/glitchless/README.md
@@ -191,7 +191,7 @@ Bike Menu:
 
 BC:
 - BB
-- TB
+- Thrash
 
 ROCK TUNNEL:
 
@@ -199,7 +199,7 @@ Repel 1 step in
 
 1st guy:
 - BB
-- Thrash
+- TB
 
 2nd guy:
 - TB

--- a/docs/gen-1/red-blue/main/glitchless/README.md
+++ b/docs/gen-1/red-blue/main/glitchless/README.md
@@ -191,7 +191,7 @@ Bike Menu:
 
 BC:
 - BB
-- Thrash
+- TB
 
 ROCK TUNNEL:
 

--- a/docs/gen-1/red-blue/main/glitchless/resources/defensive-ranges.md
+++ b/docs/gen-1/red-blue/main/glitchless/resources/defensive-ranges.md
@@ -8,7 +8,6 @@
  - All rolls include 1/39 max roll
 
 ## Squirtle
-
 **Rival**
 
 Bulbasaur    | Tackle
@@ -151,8 +150,6 @@ Zubat        | Leech Life    | Self Hit
 @-2          | 11-14         | 21
 
 </td></tr> </table>
-
-_TODO_: Shall we add another Moon rocket table but with Nidoking instead? for Lass strat
 
 ## FFEF Nidoking
 
@@ -591,7 +588,7 @@ NOTE: With Gentleman candy, Nidoking will be 35 for Gyarados
 Pidgeot       | Quick Attack   | Wing Attack
 ------------- | -------------- | --------------
 &nbsp;        | 15-18 [31-37]  | 13-16 [28-33]
-'*            | 13-16          | 12-15
+\*            | 13-16          | 12-15
 
 </td><td>
 
@@ -605,7 +602,7 @@ Lv.35 Nidoking  | 83-98 [234-276]
 Growlithe     | Ember          | Take Down
 ------------- | -------------- | --------------
 &nbsp;        | 11-13 [20-24]  | 18-22 [38-45]
-'*            |                | 17-20
+@+1           | 8-10           |
 
 </td></tr> </table>
 
@@ -720,7 +717,7 @@ Nidoking      | Thrash        | Horn Attack    | Tackle
 
 Rhyhorn       | Fury Attack   | Stomp          | Horn Attack
 ------------- | ------------- | -------------- | --------------
-'*            | 5-6 [10-12]   | 17-20 [38-45]  | 17-20 [38-45]
+\*            | 5-6 [10-12]   | 17-20 [38-45]  | 17-20 [38-45]
 
 </td><td>
 
@@ -728,8 +725,7 @@ Venusaur      | Razor Leaf    | Vine Whip
 ------------- | ------------- | --------------
 &nbsp;        | 18-22 [74-87] | 12-15 [46-55]
 
-<table>
-<tr><td>
+</td></tr> </table>
 
 **Lorelei**
 
@@ -745,7 +741,7 @@ Onix          | Slam          | Rock Throw     | Rage
 &nbsp;        | 17-20 [35-42] | 7-9 [17-20]    | 5-6 [10-12]
 
 ### Agatha
-_TODO_:wing attack without badge boost? bite without badge boost?
+_TODO_:wing attack with badge boost? bite without badge boost?
 <table>
 <tr><td>
 
@@ -757,7 +753,7 @@ Golbat        | Wing Attack    | Self Hit
 
 Arbok         | Bite
 ------------- | --------------
-'*            | 22-26 [51-60]
+\*            | 22-26 [51-60]
 
 </td></tr> </table>
 
@@ -773,12 +769,12 @@ Gyarados      | Hydro Pump
 
 Pidgeot       | Sky Attack    | Wing Attack'
 ------------- | --------------- | --------------
-'*            | 72-85 [177-207] | 18-22 [45-53]
+\*            | 72-85 [177-207] | 18-22 [45-53]
 
 </td><td>
 
 Rhydon        | Fury Attack
 ------------- | -------------
-'*            | 9-11 [20-24]
+\*            | 9-11 [20-24]
 
 </td></tr> </table>

--- a/docs/gen-1/red-blue/main/glitchless/resources/offensive-ranges.md
+++ b/docs/gen-1/red-blue/main/glitchless/resources/offensive-ranges.md
@@ -4,6 +4,7 @@
  - `move`* denotes a badge boost, `move`** denotes 2, etc.
  - `move`@-1 denotes a defensive stat drop, `move`@-2 denotes 2, etc.
  - `move`# denotes a critical hit
+ - images located in dropdowns are visual cue for guaranteed rolls
 
 
 ## Squirtle
@@ -11,54 +12,62 @@ _TODO_: shall we add route1 encounter and weedle guy ranges?
 
 ## FFEF NidoranM
 ### Route 3
-**Bug Catcher 1** _TODO_ caterpie 2 is wrong
+**Bug Catcher 1** _TODO_ add caterpie 2 %, rattata %
 <table>
 <tr><td>
 
-Caterpie                          | &nbsp;
---------------------------------- | ------
-Leer + Horn Attack x2             |	18.9%
-Leer + Horn Attack + Horn Attack* | 78.4%
+| Caterpie                          | &nbsp;|
+| --------------------------------- | ------|
+| Leer + Horn Attack x2             |	18.9% |
+| Leer + Horn Attack + Horn Attack* | 78.4% |
 
 </td><td>
 
-Weedle                       | &nbsp;
----------------------------- | ------
-Leer + Horn Attack x2        |	100%
-Leer + Horn Attack + Tackle  | 52.9%
-Leer + Horn Attack + Tackle* | 83.7%
+| Weedle                       | &nbsp;|
+| ---------------------------- | ----- |
+| Leer + Horn Attack x2        |	100% |
+| <details><summary>Leer + Horn Attack + Tackle</summary><br><img src="https://i.imgur.com/XIZP3Cp.png" width="250"></details> | 52.9% |
+| <details><summary>Leer + Horn Attack + Tackle*</summary><br><img src="https://i.imgur.com/vKaAW1B.png" width="250"></details> | 83.7% |
 
 </td><td>
 
-Caterpie      | &nbsp;
-------------  | ------
-Horn Attack x2| ~~100%~~
+| Caterpie      | &nbsp;|
+| ------------  | ------|
+| <details><summary>Leer + Horn Attack + Tackle</summary><br><img src="https://i.imgur.com/ATRw3x5.png" width="250"></details> | ? |
 
 </td></tr> </table>
 
-**Bug Catcher 2** _TODO_ caterpie 2 is wrong
-<table>
-<tr><td>
+**Short Guy**
 
-Weedle               | &nbsp;
--------------------- | ------
-Horn Attack + Tackle | 57.1%
-Horn Attack + Tackle*| 86.5%
+| Rattata       | &nbsp; |
+| ------------  | ------ |
+| <details><summary>Leer + Horn Attack + Tackle </summary><br><img src="https://i.imgur.com/YsRYZxZ.png" width="250"></details> | ? |
+| <details><summary>Leer + Horn Attack + Tackle* </summary><br><img src="https://i.imgur.com/fvhiH5F.png" width="250"></details> | ? |
+| <details><summary>Leer + Horn Attack + Tackle** </summary><br><img src="https://i.imgur.com/gd0ruiU.png" width="250"></details> | ? |
 
-</td><td>
 
-Caterpie             | &nbsp;
--------------------- | ------
-Horn Attack + Tackle | 0%
-Horn Attack + Tackle*| ~~0%~~
+**Bug Catcher 2**
 
-</td></tr> </table>
+| Weedle               | &nbsp; |
+| -------------------- | ------ |
+|<details><summary>Horn Attack + Tackle</summary><br><img src="https://i.imgur.com/ic8Y6a9.png" width="250"></details> | 57.1% |
+|<details><summary>Horn Attack + Tackle*</summary><br><img src="https://i.imgur.com/7i95Mxx.png" width="250"></details> | 86.5% |
 
 **Bug Catcher 3**
+<table>
+<tr><td>
 
-Caterpie       | &nbsp;
--------------- | ------
-Horn Attack x2 | 100%
+| Caterpie       | &nbsp; |
+| -------------- | ------ |
+| Horn Attack x2 | 100%   |
+
+</td><td>
+
+| Metapod             | &nbsp; |
+| ------------------- | ------ |
+|<details><summary>Tackle after 3 Hardens</summary><br><img src="https://i.imgur.com/yUFH91L.png" width="250"></details> | ? |
+
+</td></tr> </table>
 
 ### Mt. Moon
 
@@ -66,46 +75,44 @@ Horn Attack x2 | 100%
 <table>
 <tr><td>
 
-Rattata                    | &nbsp;
--------------------------- | ------
-Horn Attack x2             | 16.8%
-Horn Attack + Horn Attack* | 75.0%
-Leer + Horn Attack + Tackle| 100%
+| Rattata                    | &nbsp; |
+| -------------------------- | ------ |
+| Horn Attack x2             | 16.8%  |
+| Horn Attack + Horn Attack* | 75.0%  |
+| Leer + Horn Attack + Tackle| 100%   |
 
 </td><td>
 
-Zubat                       | &nbsp;
---------------------------- | ------
-Leer + Horn Attack + Tackle | 99.7%
-after Leech Life            | 58.7%
-after 2 Leech Life          | 1.7%
+| Zubat                       | &nbsp; |
+| --------------------------- | ------ |
+| Leer + Horn Attack + Tackle | 99.7%  |
+| after Leech Life            | 58.7%  |
+| after 2 Leech Life          | 1.7%   |
 
 </td></tr> </table>
 
-_TODO_: Shall we add another Moon rocket table but with Nidoking instead? for Lass strat
 ## FFEF Nidoking
 
 **Nerd**
 <table>
 <tr><td>
 
-Grimer                 | &nbsp;
----------------------- | ------
-Mega Punch + Water Gun | 85.7%
+| Grimer                 | &nbsp; |
+| ---------------------- | ------ |
+| <details><summary>Mega Punch + Water Gun</summary><br><img src="https://i.imgur.com/mp0BlQ0.png" width="250"></details> | 85.7% |
 
 </td><td>
 
-Voltorb      | &nbsp;
------------- | ------
-Mega Punch   | 20.5%
-Mega Punch*	 | 71.7%
+| Voltorb      | &nbsp; |
+| ------------ | ------ |
+| Mega Punch   | 20.5%  |
+| Mega Punch*	 | 71.7%  |
 
 </td><td>
 
-Koffing                 | &nbsp;
------------------------ | ------
-Mega Punch x2           | 100%
-Mega Punch* + Water Gun | 44.7%
+| Koffing                 | &nbsp; |
+| ----------------------- | ------ |
+| <details><summary>Mega Punch* + Water Gun</summary><br><img src="https://i.imgur.com/8atw4Ee.png" width="250"></details> | 44.7% |
 
 </td></tr> </table>
 
@@ -115,25 +122,24 @@ _TODO_ instead of mega punch crit we should have horn attack crit into megapunch
 <table>
 <tr><td>
 
-Pidgeotto                   | &nbsp;
---------------------------- | ------
-Horn Attack x3              | 85.1%
-Mega Punch + Horn Attack x2 | 100%
-Mega Punch# + Mega Punch    | 100%
-Mega Punch# + Horn Attack   | 35.5%
+| Pidgeotto                   | &nbsp; |
+| --------------------------- | ------ |
+| <details><summary>Horn Attack x3 </summary><br><img src="https://i.imgur.com/pFyHKZv.png" width="250"></details> | 85.1% |
+| <details><summary>Horn Attack# + Mega Punch</summary><br><img src="https://i.imgur.com/5GWD4ye.png" width="250"></details> | ? |
 
 </td><td>
 
-Rattata      | &nbsp;
------------- | ------
-Mega Punch   | 100%
-Horn Attack* | 51.2%
+| Rattata      | &nbsp;|
+| ------------ | ------|
+| Horn Attack* | 51.2% |
 
 </td><td>
 
-Bulbasaur                | &nbsp;
------------------------  | ------
-Mega Punch + Horn Attack | 100%
+| Bulbasaur                | &nbsp; |
+| -----------------------  | ------ |
+| <details><summary>Mega Punch + Horn Attack@-1</summary><br><img src="https://i.imgur.com/1Wd7xCX.png" width="250"></details>  | ? |
+| <details><summary>Mega Punch# + Posion Sting</summary><br><img src="https://i.imgur.com/lPCZgOh.png" width="250"></details> | ? |
+
 
 </td></tr> </table>
 
@@ -190,18 +196,19 @@ Mega Punch   | 71.9%
 
 </td><td>
 
-NidoranF     | &nbsp;
------------- | ------
-Horn Attack# | 41.0%
+| NidoranF     | &nbsp; |
+| ------------ | ------ |
+| Horn Attack# | 41.0%  |
+| <details><summary>Horn Attack + Horn Attack@-1</summary><br><img src="https://i.imgur.com/TXYYsCM.png" width="250"></details> | ? |
 
 </td></tr> </table>
 
 **Mankey Guy**
 
-Mankey       | &nbsp;
------------- | ------
-Mega Punch   | 15.3%
-Horn Attack# | 100%
+| Mankey      | &nbsp; |
+|------------ | ------ |  
+|Mega Punch   | 15.3%  |
+|<details><summary>Horn Attack + Poison Sting</summary><br><img src="https://i.imgur.com/IfiyNIR.png" width="250"></details> | ? |
 
 ### Misty
 
@@ -236,9 +243,10 @@ Thrash			 | 92.3%
 
 **Misty**
 
-Starmie      | &nbsp;
------------- | ------
-Thrash x2    | 99.7%
+| Starmie      | &nbsp; |
+| ------------ | ------ |
+| Thrash x2    | 99.7%  |
+| <details><summary>Trash + Trash@-1 + Poison Sting@-1</summary><br><img src="https://i.imgur.com/2kylKlG.png" width="250"></details> | ? |
 
 ### Surge
 
@@ -266,10 +274,18 @@ Thrash + Thrash@-1 | 100%
 
 **Surge**
 
-Voltorb	     | &nbsp;
------------- | ------
-Thrash			 | 69.2%
-Bubblebeam x2| 98.9%
+| Voltorb	     | &nbsp; |
+| ------------ | ------ |
+| Thrash			 | 69.2%  |
+|<details><summary>Bubblebeam x2</summary><br><img src="https://i.imgur.com/y2mhzgH.png" width="250"></details> | 98.9% |
+
+</td><td>
+
+| Raichu	     | &nbsp;|
+|------------ | ------ |
+| <details><summary>Thrash + Bubblebeam</summary><br><img src="https://i.imgur.com/J6J72b0.png" width="250"></details> | ? |
+
+</td></tr> </table>
 
 ### Fly
 
@@ -343,6 +359,12 @@ Arbok 	         | &nbsp;
 ---------------- | ------
 Thrash x2        | 43.4%
 Thrash + Thrash* | 94.1%
+
+**Juggler 2**
+
+| Hypno 	         | &nbsp; |
+| ---------------- | ------ |
+|<details><summary>Earthquake + Bubblebeam</summary><br><img src="https://i.imgur.com/UXijDJt.png" width="250"></details> | ? |
 
 ### Giovanni
 


### PR DESCRIPTION
-add visual cues for offensive ranges (credits to hwangbro for the images)
-removed some useless offensive ranges
-fixed a couple of defensive ranges
-fixed a wrong move in the red guide
- made a pretty cool BTW guide
- stitch togheter a 1024 charmander manip guide from various pastebins (most from entrpntr) and also added new stuff like practice rom
- add 151FLT and RBA guides. these are based from lucky/krazyd4an pastebins that were 0% beginner friendly. i added more BTW options and cleared a couple of things, but some work is still needed