### PR TITLE
Fix 404 Nido manip link

### DIFF
--- a/docs/gen-1/yellow/main-glitchless/README.md
+++ b/docs/gen-1/yellow/main-glitchless/README.md
@@ -36,7 +36,7 @@
     - 5 Potions
 - Go through the Old Man catching tutorial
 - Save on [this tile](https://gunnermaniac.com/pokeworld?map=1#57/141) (MAKE SURE YOU STOP MOVING BEFORE OPENING THE PAUSE MENU, THE SAVE MUST BE UNBUFFERED)
-- Perform [Nido manip](/resources/yellow/nido-manip.md)
+- Perform [Nido manip](resources/nido-manip.md)
 - Nickname nido one character
 
 ## Viridian Forest


### PR DESCRIPTION
Nido manip link in Viridian City section gives a 404. I changed it to be the same as the working link at the start of the guide.