### PR TITLE
Replace links to use relative paths

### DIFF
--- a/docs/gen-1/red-blue/catext/catch-em-all-classic/README.md
+++ b/docs/gen-1/red-blue/catext/catch-em-all-classic/README.md
@@ -18,7 +18,7 @@ If something isn't clear, you should watch:
 ## Brock Through Walls
 
 The first glitch we will perform is called Brock Through Walls.
-A detailed guide on what strategy could be best for you and how to execute it can be found [here](/gen-1/red-blue/catext/reverse-badge-acquisition/resources/Brock-Through-Walls-Guide)
+A detailed guide on what strategy could be best for you and how to execute it can be found [here](../reverse-badge-acquisition/resources/Brock-Through-Walls-Guide.md)
 
 - **[PP/Pidgey Strat]** Viridian shop: buy
 	- 10 Pokeballs
@@ -26,7 +26,7 @@ A detailed guide on what strategy could be best for you and how to execute it ca
 - Pick up forest potion
 - Fight Weedle Guy
 - **[PP/Pidgey Strat]** Pewter shop: buy
-  - 1escape rope  
+  - 1escape rope
   - 1 parlyz heal
   - 1 burn heal
   - 1 awakening
@@ -158,7 +158,7 @@ A detailed guide on what strategy could be best for you and how to execute it ca
 | ---------- | --------- | ------------ | --------------- |
 | Oddish 		 | 5 				 | 5 				 		| 5								|
 | Squirtle	 |					 |					 		| 4								|
-| Charmander | 3 				 | 3 				 		|					  			|					
+| Charmander | 3 				 | 3 				 		|					  			|
 | Magnemite  | 3 				 | 2 				 		| 2								|
 | Ponyta 		 | 5 				 | 5 				 		| 5								|
 | Goldeen 	 | 2 				 | 2 				 		| 2								|

--- a/docs/gen-1/red-blue/catext/reverse-badge-acquisition/README.md
+++ b/docs/gen-1/red-blue/catext/reverse-badge-acquisition/README.md
@@ -14,7 +14,7 @@ If something isn't clear,you should watch:
 ## Brock Through Walls
 
 The first glitch we will perform is called Brock Through Walls.
-A detailed guide on what strategy could be best for you and how to execute it can be found [here](/gen-1/red-blue/catext/reverse-badge-acquisition/resources/Brock-Through-Walls-Guide)
+A detailed guide on what strategy could be best for you and how to execute it can be found [here](resources/Brock-Through-Walls-Guide.md)
 
 - **[1024 Charmander]** [Route 1 to weedle manip](https://www.youtube.com/watch?v=ZbAv0m19v9g)
 - **[PP/Pidgey Strat]** Viridian shop: buy

--- a/docs/gen-1/red-blue/catext/reverse-badge-acquisition/resources/Brock-Through-Walls-Guide.md
+++ b/docs/gen-1/red-blue/catext/reverse-badge-acquisition/resources/Brock-Through-Walls-Guide.md
@@ -20,14 +20,14 @@ This is the hardest but also faster method.
 It requires a 1-frame rename after multiples 4-frames textboxes.
 Because of this, this method should be used only by runners aiming for top times, and only after a lot of practice.
 
-A guide to the manipulation itself can be found [here](/gen-1/red-blue/catext/reverse-badge-acquisition/resources/1024-charmander-manip)
+A guide to the manipulation itself can be found [here](1024-charmander-manip.md)
 
 After correctly performing it, Weedle fight must be done in specific way to assure correct PP after the fight.
 
 ### Weedle guy
 
 Two basic options
-1.  (swap Scratch/Growl), Growl x2, Scratch x7  
+1.  (swap Scratch/Growl), Growl x2, Scratch x7
 2.   Scratch x6  (only ~5% to kill); if Weedle's still alive:
     - if 1 Scratch kills (guaranteed to kill if no Gen 1 misses)  ::  (swap Scratch/Growl), Growl x2, Scratch x1
     - if 1 Scratch doesn't kill (only possible if Gen 1 missed)   ::  Scratch x2
@@ -83,12 +83,12 @@ Continue from ###Pidgey _TODO_ make a link
   - 13 Special: Kill one extra encounter. Lv2 Pidgeys or Lv2/3 Rattatas are preferred
   - 14 Special: Run from anything you see, no extra experience needed
 
-### Pidgey  
+### Pidgey
 - You will need to catch a Pidgey with the current HP value (8-10-13-15-16-17). You can either:
   - Catch a random Pidgey and hope it has good HP
   - Do Pidgey manipulation
 
-   1 character Bulbasaur        | full name Bulbasaur          
+   1 character Bulbasaur        | full name Bulbasaur
    ---------------------------- | ----------------------------
   [1 character player name](https://youtu.be/a4joVzaCMXk) | _TODO_ from 151autumn route |
   [5 characters player name](https://youtu.be/Ua0ZyWffYpU) | NA as far as i know          |

--- a/docs/gen-1/red-blue/main-glitchless/advanced-route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/advanced-route/README.md
@@ -18,9 +18,9 @@ Route 1
 Viridian Mart
 - Buy 3 Poke Balls
 
-Do [Nido Manip](/gen-1/red-blue/main-glitchless/resources/nido-manip.md)
+Do [Nido Manip](../resources/nido-manip.md)
 
-Do [Triple Extended Manip](/gen-1/red-blue/main-glitchless/resources/triple-extended)
+Do [Triple Extended Manip](../resources/triple-extended)
 
 ## BROCK SPLIT
 
@@ -437,7 +437,7 @@ Rival:
  - If you used too many Blizzards on Rhydon, can Drill Rhyhorn
  - TB Gyarados if you Elixired early
  -  EQ Rhyhorn if you used too many Blizzards on Rhydon and you Elixired early
- 
+
 Pick up the hidden Max Ether and use it on Horn Drill on final Victory Road Menu
 
 Deposit Squirtle and Paras

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/README.md
@@ -4,13 +4,13 @@
 
 ## Manip Quick Reference:
 - Nidoran Manip:
-  - [Optimal (HIGHLY RECOMMENDED)](/gen-1/red-blue/main-glitchless/resources/nido-manip)
+  - [Optimal (HIGHLY RECOMMENDED)](../resources/nido-manip)
   - [1 A Press](https://youtu.be/qPzSWHyMuW8)
 - Mount Moon Manip:
   - [Inside Moon](https://pastebin.com/jnj9j47S) (Optimal for this route)
   - Backups (in case you fail the full manip):
 	- [2nd Floor Backup (string manip)](https://pastebin.com/j5gtY4cy)
-	- [Post Nerd Backup Paras](/gen-1/red-blue/main-glitchless/resources/postnerd-backup-paras)
+	- [Post Nerd Backup Paras](../resources/postnerd-backup-paras)
 - Surge Cans Manip:
   - [Optimal](https://www.youtube.com/watch?v=8Pa2f2WxCe4)
   - [Pallete Cans ](https://youtu.be/_tWhfBITf_g)(aka 'Cheater' Palette, allows you to see through Rock Tunnel)
@@ -19,8 +19,8 @@
 - [HP Dependent Strats](https://pastebin.com/HgyuMvyr)
 - [Original Route made in 2019](https://pastebin.com/7HRZxXKS)
 	* This route is still good, and if you already know Route 3 Moon Manip you may want to use this instead
-- [Defensive Damage Ranges](/gen-1/red-blue/main-glitchless/resources/defensive-ranges)
-- [Offensive Damage Ranges](/gen-1/red-blue/main-glitchless/resources/offensive-ranges)
+- [Defensive Damage Ranges](../resources/defensive-ranges)
+- [Offensive Damage Ranges](../resources/offensive-ranges)
 
 ### Glossary:
 - Moves: HA = Horn Attack, MP = Mega Punch, BB = Bubble Beam, WG = Water Gun, TB = Thunder Bolt, Bliz = Blizzard, PS = Poison Sting, HD = Horn Drill, RS = Rock Slide
@@ -44,7 +44,7 @@
 + Shopping:
 	+ 4 Pokeballs (This does require you to get consistent at manip yoloballs, you can buy 5 and 1 less potion later on)
 * Nidoran Manip:
-  * [Optimal (HIGHLY RECOMMENDED)](/gen-1/red-blue/main-glitchless/resources/nido-manip)
+  * [Optimal (HIGHLY RECOMMENDED)](../resources/nido-manip)
   * [1 A Press](https://youtu.be/qPzSWHyMuW8)
 - Get the tree potion [here](http://gunnermaniac.com/pokeworld?map=1#54/166)
 
@@ -114,7 +114,7 @@ Don't stress too much doing the longer manips just learn Post Nerd Backup Paras 
 - [Inside Moon](https://pastebin.com/jnj9j47S) (Optimal for this route)
 - Backups (in case you fail the full manip):
   - [2nd Floor Backup (PoY v2.0)](https://pastebin.com/j5gtY4cy)
-  - [Post Nerd Backup Paras](/gen-1/red-blue/main-glitchless/resources/postnerd-backup-paras)
+  - [Post Nerd Backup Paras](../resources/postnerd-backup-paras)
 
 - Get TM 12 (Water Gun), Rare Candy, Escape Rope, TM 01 (Mega Punch), Moon Stone during mount moon manip
 - MENU after Paras and Before Rocket:
@@ -499,7 +499,7 @@ NOTE: From this point on you have 2 revives which means deaths aren't as scary, 
 
 **Sabrina:**
 - EQ x4
-- Walk back to the Teleporter and dig out and fly to  
+- Walk back to the Teleporter and dig out and fly to
 
 ## Viridian City
 **Cooltrainer:**

--- a/docs/gen-1/red-blue/main-glitchless/race-route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/race-route/README.md
@@ -4,26 +4,26 @@
 **You can find the VOD of the Finals[here](https://youtu.be/owoeSjzdqL0), it's a good example of this route in action**
 
 ## Manip Quick Reference:
-- [Nidoran Manip](/gen-1/red-blue/main-glitchless/resources/nido-manip)
-- [Triple Extended Manip](/gen-1/red-blue/main-glitchless/resources/triple-extended)
+- [Nidoran Manip](../resources/nido-manip)
+- [Triple Extended Manip](../resources/triple-extended)
 - [Pidgey Backup](https://youtu.be/WLigwIbp2ps)
 - Mount Moon Manip:
   - [Inside Moon](https://pastebin.com/jnj9j47S)
    - mandatory if you did Lass
-  - [R3 Moon Manip](https://pastebin.com/tggXpQRC) 
+  - [R3 Moon Manip](https://pastebin.com/tggXpQRC)
    - this is slightly better but can only use it if you skip Lass
   - Backups (in case you fail the full manip):
 	- [2nd Floor Backup (string manip)](https://pastebin.com/j5gtY4cy)
-	- [Post Nerd Backup Paras](/gen-1/red-blue/main-glitchless/resources/postnerd-backup-paras)
-    - [Oddish Backup](/gen-1/red-blue/main-glitchless/resources/oddish-backup)
+	- [Post Nerd Backup Paras](../resources/postnerd-backup-paras)
+    - [Oddish Backup](../resources/oddish-backup)
 - Surge Cans Manip:
   - [Optimal](https://www.youtube.com/watch?v=8Pa2f2WxCe4)
   - [Pallete Cans ](https://youtu.be/_tWhfBITf_g)(aka 'Cheater' Palette, allows you to see through Rock Tunnel)
 
 ## Good Documents:
 - [HP Dependent Strats](https://pastebin.com/HgyuMvyr)
-- [Defensive Damage Ranges](/gen-1/red-blue/main-glitchless/resources/defensive-ranges)
-- [Offensive Damage Ranges](/gen-1/red-blue/main-glitchless/resources/offensive-ranges)
+- [Defensive Damage Ranges](../resources/defensive-ranges)
+- [Offensive Damage Ranges](../resources/offensive-ranges)
 
 ### Glossary:
 - Moves: HA = Horn Attack, MP = Mega Punch, BB = Bubble Beam, WG = Water Gun, TB = Thunder Bolt, Bliz = Blizzard, PS = Poison Sting, HD = Horn Drill, RS = Rock Slide
@@ -46,8 +46,8 @@
   - During the parcel quest kill one encounter from a level 2 rat, level 3 rat, or a level 2 pidgey. You can fight level 3 pidgeys but you will take a bit of damage if you have a lower attack (10-11 at Lv6) squirtle. This Early XP will get you Bubble for Brock
 - SHOPPING:
 	- 4 Pokeballs (This does require you to get consistent at manip yoloballs, you can buy 5 and 1 less potion later on)
-- [Nidoran Manip](/gen-1/red-blue/main-glitchless/resources/nido-manip)
-- [Triple Extended Manip](/gen-1/red-blue/main-glitchless/resources/triple-extended)
+- [Nidoran Manip](../resources/nido-manip)
+- [Triple Extended Manip](../resources/triple-extended)
 - Get the tree potion [here](http://gunnermaniac.com/pokeworld?map=1#54/166)
 
 ## Viridian Forest:
@@ -100,7 +100,7 @@
 
 **Bug Catcher 2:** [Heal on caterpie if HP < 7]
 * HA Spam all pokes finish pokemon with tackle when possible
-- Here you need to decide if you want to do Lass or not. 
+- Here you need to decide if you want to do Lass or not.
  - if you have more than 8/9 HA, skip Lass
  - if you have red bar for BC3, consider skipping Lass even at low HA count
  - if you want to play 100% safe, always do Lass
@@ -134,12 +134,12 @@
 - Mount Moon Manip:
   - [Inside Moon](https://pastebin.com/jnj9j47S)
    - mandatory if you did Lass
-  - [R3 Moon Manip](https://pastebin.com/tggXpQRC) 
+  - [R3 Moon Manip](https://pastebin.com/tggXpQRC)
    - this is slightly better but can only use it if you skip Lass
   - Backups (in case you fail the full manip):
 	- [2nd Floor Backup (string manip)](https://pastebin.com/j5gtY4cy)
-	- [Post Nerd Backup Paras](/gen-1/red-blue/main-glitchless/resources/postnerd-backup-paras)
-    - [Oddish Backup](/gen-1/red-blue/main-glitchless/resources/oddish-backup)
+	- [Post Nerd Backup Paras](../resources/postnerd-backup-paras)
+    - [Oddish Backup](../resources/oddish-backup)
 
 - Get TM 12 (Water Gun), Rare Candy, Escape Rope, TM 01 (Mega Punch), Moon Stone during mount moon manip
 
@@ -150,7 +150,7 @@
 	* Use Rare Candy
 	* Use Moon Stone
 	* Teach TM 01 (Mega Punch) over Leer (Slot 1)
-	
+
 **Rocket:**
 * Rat: MP
 * Zubat: MP + PS (HA/Tackle if zubat uses leech life and crits)
@@ -164,10 +164,10 @@
 	* Toss any remaining Pokeballs (ONLY IF YOU HAVE A PARAS)
 	* Toss Antidote if you still have it
 	* Use Rare Candy
-	* Teach TM 12 (Water Gun) over Tackle (Slot 2) 
+	* Teach TM 12 (Water Gun) over Tackle (Slot 2)
 	* Use Moon Stone
 	* Teach TM 01 (Mega Punch) over Leer (Slot 1)
-	
+
 **Super Nerd:**
 * Grimer: MP + HA (Tackle if out of HA)
 * Voltorb: MP + (PS)
@@ -264,7 +264,7 @@ If you are less than 15 HP do the following:
 * Teach BB over PS
 
 If you still miss a cutter:
-  - [Oddish Backup](/gen-1/red-blue/main-glitchless/resources/oddish-backup)
+  - [Oddish Backup](../resources/oddish-backup)
 
 ## Vermilion City:
 **Female Jr:**
@@ -389,7 +389,7 @@ Shopping:
 	* Swap slot 3 with X Accs
 	* Teach HM 02 to the bird
 	* Use Fly to go to Lavender
-	
+
 _TODO_ add early drill strat
 
 ## Lavender Town
@@ -543,7 +543,7 @@ NOTE: From this point on you have 2 revives which means deaths aren't as scary, 
 
 **Sabrina:**
 - EQ x4
-- Walk back to the Teleporter and dig out and fly to  
+- Walk back to the Teleporter and dig out and fly to
 
 ## Viridian City
 **Cooltrainer:**

--- a/docs/gen-1/red-blue/main-glitchless/resources/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/resources/README.md
@@ -1,9 +1,9 @@
 # Resources for Pokemon Red-Blue Glitchless
 
-* [Defensive Ranges](defensive-ranges)
-* [Nido Manip](nido-manip)
-* [Oddish Backup](oddish-backup)
-* [Offensive Ranges](offensive-ranges)
-* [Post-Nerd Backup Paras](postnerd-backup-paras)
-* [Route 3 Moon Backups](rt3moon-f36-f37-backups)
-* [Triple Extended](triple-extended)
+* [Defensive Ranges](defensive-ranges.md)
+* [Nido Manip](nido-manip.md)
+* [Oddish Backup](oddish-backup.md)
+* [Offensive Ranges](offensive-ranges.md)
+* [Post-Nerd Backup Paras](postnerd-backup-paras.md)
+* [Route 3 Moon Backups](rt3moon-f36-f37-backups.md)
+* [Triple Extended](triple-extended.md)


### PR DESCRIPTION
Full paths don't properly link together when viewing guides using github interface instead of docsify.