### PR TITLE
no Lass edits

### DIFF
--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/2021/lass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/2021/lass/README.md
@@ -229,13 +229,18 @@ If you are less than 15 HP do the following:
 If you have less than 13 HP after this fight
 - Potion
   - 13+ HP lives QA x2, Wine Whip + QA non crits, and Wine Whip Crit
-- Teach BB over PS
+- Teach TM 11 BB over PS
 
-**Rival:**
-- Pidgeotto: HA x2
+**Boat Rival:**
+- Pidgeotto: HAx2 (BB turn 2 if taught; potion turn 2 if under 7 hp)
 	* If you get sand attacked swap to another pokemon and let it die
-* Rat: MP
-* Kadabra: Thrash
+* Rat:
+  - HP < 7 : Potion
+  - HP = 7-22 : MP  [Note: potion on 7-12 hp is extra safe]
+  - HP = 23+ : HA + PS or BBx2
+* Kadabra:
+  - HP < 7 : HA Kadabra & Potion turn 1 on Ivysaur, then thrash
+  - HP = 7+ : Thrash Kadabra
 
 If you have less than 9 HP and IT, Fight the Gentleman in [this room here](https://gunnermaniac.com/pokeworld?map=96#21/11) with thrash then pickup the rare candy
 

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/2021/lass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/2021/lass/README.md
@@ -458,7 +458,7 @@ NOTE: From this point on you have 2 revives which means deaths aren't as scary, 
 - EQ x3
 - Elixer on Weezing
   - if Koga used x attack use Bubblebeam till you die
-  - if you didn’t die from koga you can still try to get red bar by following the HP strats for the [backups](https://pastebin.com/2DBBnkmf). Note that this can be risky
+  - if you didn’t die from koga you can still try to get red bar by following the HP strats for the [backups](https://pastebin.com/HgyuMvyr). Note that this can be risky
 + MENU After Koga:
   + Use all Rare Candies
   + Bike to get Strength
@@ -554,7 +554,7 @@ NOTE: From this point on you have 2 revives which means deaths aren't as scary, 
 - Before Bruno use a Max Ether on HD
 
 **Bruno:**
-- X ACC, Blizz, HD x2, Blizz, HD
+- X ACC, HDx5
 
 MENU before Agatha:
 * Super Potion with 19 or more HP

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/2021/lass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/2021/lass/README.md
@@ -458,7 +458,7 @@ NOTE: From this point on you have 2 revives which means deaths aren't as scary, 
 - EQ x3
 - Elixer on Weezing
   - if Koga used x attack use Bubblebeam till you die
-  - if you didn’t die from koga you can still try to get red bar by following the HP strats for the [backups](https://pastebin.com/HgyuMvyr). Note that this can be risky
+  - if you didn’t die from koga you can still try to get red bar by following the HP strats for the [backups](https://pastebin.com/2DBBnkmf). Note that this can be risky
 + MENU After Koga:
   + Use all Rare Candies
   + Bike to get Strength
@@ -554,7 +554,7 @@ NOTE: From this point on you have 2 revives which means deaths aren't as scary, 
 - Before Bruno use a Max Ether on HD
 
 **Bruno:**
-- X ACC, HDx5
+- X ACC, Blizz, HD x2, Blizz, HD
 
 MENU before Agatha:
 * Super Potion with 19 or more HP

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/2021/nolass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/2021/nolass/README.md
@@ -250,13 +250,18 @@ If you are less than 15 HP do the following:
 If you have less than 13 HP after this fight
 - Potion
   - 13+ HP lives QA x2, Wine Whip + QA non crits, and Wine Whip Crit
-- Teach BB over PS
+- Teach TM 11 BB over PS
 
-**Rival:**
-- Pidgeotto: HA x2
+**Boat Rival:**
+- Pidgeotto: HAx2 (BB turn 2 if taught; potion turn 2 if under 7 hp)
 	* If you get sand attacked swap to another pokemon and let it die
-* Rat: MP
-* Kadabra: Thrash
+* Rat:
+  - HP < 7 : Potion
+  - HP = 7-22 : MP  [Note: potion on 7-12 hp is extra safe]
+  - HP = 23+ : HA + PS or BBx2
+* Kadabra:
+  - HP < 7 : HA Kadabra & Potion turn 1 on Ivysaur, then thrash
+  - HP = 7+ : Thrash Kadabra
 
 If you have less than 9 HP and IT, Fight the Gentleman in [this room here](https://gunnermaniac.com/pokeworld?map=96#21/11) with thrash then pickup the rare candy
 

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/2021/nolass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/2021/nolass/README.md
@@ -80,7 +80,7 @@
 * Caterpie: Leer + HA x2 + (Tackle)
 * Weedle: Leer + HA x2
 	- Leer + HA + Tackle if you got stringshot hit OR tackle will always kill
-* Caterpie: HA x2 + Tackle
+* Caterpie: Leer + HA + Tackle
 - Menu: Use a potion if HP < 25
 
 **Shorts Guy:**
@@ -96,17 +96,18 @@
 * Kakuna:
   - HA spam (Tackle to finish)
 * Caterpie:
-  - HA x2
+  - HA x2 (Tackle turn 2 if hit by two string shots from Weedle)
 * Metapod:
   - HA x2 + Tackle
 
 **Bug Catcher 3:**
 - Caterpie:
   - HA x2
-- Metapod:
+- Metapod: (note: you need at least 2 HAs after this fight)
   - HA spam, Tackle to finish
 + Catch a Flyer
-  + Tackle then toss a ball at any flyer expect level 8s where you HA then toss a ball
+  + Tackle then toss a ball at any flyer except level 8 Pidgey where you HA then toss a ball 
+  + Exception: if only 2 HAs are left, then weaken L8 Pidgey with Leer + Tackle
 
 ## Mount Moon
 **Mount Moon Manip:**
@@ -124,10 +125,10 @@ Don't stress too much doing the longer manips just learn Post Nerd Backup Paras 
 
 **Rocket:**
 * 1 HA:
-	- Rat: Leer + Tackle x2
+	- Rat: Leer + Tackle x2 (+PS)
 	- Zubat: Leer + Tackle + HA (+Tackle)
 * 2 HA:
-	- Rat: Leer + HA + Tackle (+PS)
+	- Rat: Leer + HA + Tackle (or PS turn 3 if tail whip hit or PS always KOs)
 	- Zubat: Leer + Tackle + HA (+Tackle)
 * 3 HA:
 	- Rat: HA x2 (+PS)
@@ -217,6 +218,7 @@ Don't stress too much doing the longer manips just learn Post Nerd Backup Paras 
 * MP
 * HA
 * MP (Use HA if you fought the extra Moon encounter)
+* teach Thrash over Water Gun
 
 - MENU After Bill:
 	* Use Rare Candy
@@ -337,7 +339,7 @@ Surge Cans Manip:
 **Lass:**
 - Thrash
 
-- Get the Hidden Max Etehr [here](https://gunnermaniac.com/pokeworld?map=21#16/53)
+- Get the Hidden Max Ether [here](https://gunnermaniac.com/pokeworld?map=21#16/53)
 
 ## Route 8
 **Gambler:**
@@ -366,8 +368,8 @@ Shopping:
 	- Come back and buy a Fresh Water
 * Floor 5:
 	- Buy 12 X Accs
-	- Buy 9 X Specs (8 if you have 0 potions at this point)
-	- Buy 1 X Speeds (2 if you have 0 potions at this point)
+	- Buy 9 X Specs (7 if you have 0 potions at this point)
+	- Buy 1 X Speeds (3 if you have 0 potions at this point)
 - Take the Elevator and get HM 02 (Fly)
 - MENU after getting Fly:
 	* Swap slot 2 with TM 07 (Horn Drill)
@@ -420,7 +422,7 @@ NOTE: From this point on you have 2 revives which means deaths aren't as scary, 
 
 **Rocket 1:**
 - Thrash
-  - If you get paralyzed use a paralyze heal
+  - If you get paralyzed use a paralyze heal after the fight
 - Get the Key Card
 
 **Rival:**
@@ -550,8 +552,8 @@ NOTE: From this point on you have 2 revives which means deaths aren't as scary, 
 	+ Bike
 
 **Rival:**
-- X Acc, X Spec, Blizz, Blizz, HD, X Spec, HD x3
-	* Note: If you only have 2 Blizzards entering the fight, use TB(+TB) on Pidgeot instead of Blizz. You want at least 1 Blizzard leaving this fight.
+- X Acc, X Spec, Blizz, HDx2, X Spec (Turn 1 on Growlithe), HD x3
+- (Only if you had 0 potions and bought 3 X Speeds): X Acc, X Speed, Blizz(+TB), HDx5
 
 ## Victory Road
 - Pick up the hidden Max Ether from the water [here](https://gunnermaniac.com/pokeworld?map=34#8/90)
@@ -590,7 +592,7 @@ MENU before Agatha:
 - Golbat: Blizz
     - If you miss Blizz, and Golbat uses Haze, use
       - 2x TB on Golbat
-	  - Consider using a Super Potion on Arbok if you are between 25 HP and 60 HP.
+	  - Consider using a Super Potion on Arbok if you are between 25 HP and 60 HP (or X speed if you have one).
 	  - 25 HP and lower has red bar, and is usually worth taking the risk.
 	  - You are slower than the last Gengar, so it will have a turn to use a move on you.
     - If you miss Blizz, but Golbat doesn't use Haze, use Blizz again, or TB if out of Blizzards
@@ -618,7 +620,7 @@ If you don't have enough Potion, use the heal option below
 **Lance:**
 * Gyarados: X Spec, TB
 * Dragonair 1: Blizz
-* Dragonair 2: X Spec, Blizz
+* Dragonair 2: X Spec, Blizz (if you have an X Speed use it on Dragonair 2 instead of X Spec)
 * Aero: TB
 * Dragonite: Blizz
 


### PR DESCRIPTION
Fixed BC1 2nd Caterpie. Save 2 HAs for Moon Rocket added since Leer + Tacklex2(+PS) is terrible on Moocket Rat. Added teach thrash over wg (ty Grogir). Changed 0 potions left to 7 specs and 3 speeds along with adding when/how to use the speeds (purposefully omitted surf menu swap for simplicity). Added "after the fight" to para heal use when thrashing Silph Arbok. Changed VR Ryhorn to HD as per wsop's suggestion.