### PR TITLE
Fix Dark Mode Toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,6 @@ A wiki for viewing and editing Pokemon Speedrun routes using GitHub Pages and Do
 [View the github here](https://github.com/pokemon-speedrunning/speedrun-routes) or by clicking the GitHub icon in the top right of the live site
 
 Wiki page edits can be suggested on GitHub by navigating through the docs folder and clicking the pencil icon once you find the relevant markdown page, then after making the relevant edit you can submit a pull request by scrolling to the bottom.
+
+## Development for Site Wrapper Code
+You can test changes to the site's wrapper code in `docs/index.html` locally using Node.JS. Install docsify with `npm install docsify-cli -g` and then run `docsify serve docs` to spin up a local development server.

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,61 +5,59 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta charset="UTF-8">
   <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/themes/vue.css" />
-  <style id="darkMode" class="enabled">
-    @media (prefers-color-scheme: dark) {
-      :root {
-        --theme-color: #FFCB05;
-      }
-      html,
-      body,
-      main,
-      p,
-      .app-nav li ul,
-      .sidebar-toggle,
-      body.close .sidebar-toggle,
-      .sidebar,
-      .sidebar ul li a,
-      aside,
-      .anchor span,
-      .markdown-section h1,
-      .markdown-section h2,
-      .markdown-section h3,
-      .markdown-section h4,
-      .markdown-section strong
-      {
-        background: black;
-        color: var(--theme-color);
-      }
+  <style id="darkMode">
+    :root {
+      --theme-color: #FFCB05;
+    }
+    html,
+    body,
+    main,
+    p,
+    .app-nav li ul,
+    .sidebar-toggle,
+    body.close .sidebar-toggle,
+    .sidebar,
+    .sidebar ul li a,
+    aside,
+    .anchor span,
+    .markdown-section h1,
+    .markdown-section h2,
+    .markdown-section h3,
+    .markdown-section h4,
+    .markdown-section strong
+    {
+      background: black;
+      color: var(--theme-color);
+    }
 
-      .markdown-section a,
-      .app-nav a:hover  {
-          color: #BBB;
-      }
+    .markdown-section a,
+    .app-nav a:hover  {
+        color: #BBB;
+    }
 
-      .markdown-section tr:nth-child(2n),
-      .markdown-section code,
-      .markdown-section pre,
-      .darkModeToggle {
-        background-color: #222;
-      }
+    .markdown-section tr:nth-child(2n),
+    .markdown-section code,
+    .markdown-section pre,
+    #darkModeToggle {
+      background-color: #222;
     }
   </style>
   <style>
-    .darkModeToggle {
+    #darkModeToggle {
       color: var(--theme-color);
       position: fixed;
       bottom: 10px;
       left: 40px;
       border-radius: 6px;
     }
-    .darkModeToggle:focus {
+    #darkModeToggle:focus {
       outline: none;
     }
   </style>
 </head>
 <body>
   <div id="app"></div>
-  <button class="darkModeToggle" type="button" onclick="toggle()">Dark Mode</button>
+  <button id="darkModeToggle" type="button" onclick="toggleDarkMode()">Dark Mode</button>
   <script>
     window.$docsify = {
         name: "Pokemon Speedrun Routes",
@@ -69,18 +67,22 @@
         mergeNavbar: true,
         relativePath: true
     }
+
     var darkModeCSS = document.getElementById("darkMode");
-    var cssText = darkModeCSS.innerHTML;
-    function toggle() {
+    var darkCSSText = darkModeCSS.innerHTML;
+    function toggleDarkMode() {
       darkModeCSS = document.getElementById("darkMode");
       if (darkModeCSS) {
         darkModeCSS.parentElement.removeChild(document.getElementById("darkMode"));
       } else {
         var newElement = document.createElement('style');
         newElement.id = "darkMode";
-        newElement.innerHTML = cssText;
+        newElement.innerHTML = darkCSSText;
         document.head.appendChild(newElement);
       }
+    }
+    if (!(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+      toggleDarkMode();
     }
   </script>
   <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>


### PR DESCRIPTION
The dark mode toggle will refuse to turn on dark mode unless you have the system theme enabled. This change makes it so that the system theme is only used for the initial setting of dark mode and from there the toggle can always override the theme color.