### PR TITLE
Changed indoor pokeworld2 links to be compatible with the new format

### DIFF
--- a/docs/gen-2/gold-silver/main-any/gold-silver-backup-collision-route/README.md
+++ b/docs/gen-2/gold-silver/main-any/gold-silver-backup-collision-route/README.md
@@ -73,7 +73,7 @@ If something isn't clear, you should watch [CasualPokePlayer's run](https://yout
 
 ## End
 - Go through Mr. Pokemon's cutscene again
-- Go [here](https://gunnermaniac.com/pokeworld2?map=6666#2/5)
+- Go [here](https://gunnermaniac.com/pokeworld2?map=2610#2/5)
 - Go to Key Items pocket
 - Swap Mystery Egg in slot 1 with Mystery Egg in slot 2
 - Go to Balls pocket

--- a/docs/gen-2/gold-silver/main-any/silver-insane-collision-route/README.md
+++ b/docs/gen-2/gold-silver/main-any/silver-insane-collision-route/README.md
@@ -16,7 +16,7 @@
 - IGT track \#1 for frame 2-59 (you can probably use livesplit for this?)
 
 ## Lab
-- Save [here](https://gunnermaniac.com/pokeworld2?map=6149#4/2/) facing right buffered
+- Save [here](https://gunnermaniac.com/pokeworld2?map=2405#4/2/) facing right buffered
 	- Just buffer start after closing last elm textbox
 	- Make sure to start a timer after hitting yes on save
 - Get cynda, no nickname
@@ -24,7 +24,7 @@
 	- Add ~35327 to timer
 	- If this is too hard to hit, you can wait another 59 frames (~36312 offset instead, also makes first igt have frames 1-59 work)
 - Save [here](https://i.imgur.com/GRIB3X7.png) facing down buffered
-	- [movement](https://gunnermaniac.com/pokeworld2?map=6149#5/3/LLLDS)
+	- [movement](https://gunnermaniac.com/pokeworld2?map=2405#5/3/LLLDS)
 - Reset while saving in (0x288D, 0x2891)
 	- Same timer as second igt
 	- GBI - add ~2500


### PR DESCRIPTION
I changed pokeworld2 map ids to work with a decimal based encoding (`group*100+number`) instead of a hexadecimal based encoding (`group*256+number`), as it makes picking out the map group and map number from the combined ID easier.
This PR fixes the links that broke as a result of this change.