### PR TITLE
Fix 404 error on WR Route link

### DIFF
--- a/docs/gen-1/red-blue/main-glitchless/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/README.md
@@ -3,6 +3,7 @@
 * [Beginner Route](beginner-route/)
 * [Intermediate Route](intermediate-route/)
 * [Advanced Route](advanced-route/)
+* [WR Route](WR-Route)
 * [Race Route](race-route/)
 
 ## What route do I choose?
@@ -10,3 +11,4 @@
 - The beginner route is recommended if you first start out. It is focused toward being able to complete as many runs as possible, which is great for learning the game. You can also continue to use this route as you improve, as people have gotten times as low as 1:47s with this route.
 - The intermediate route is focused toward goal times where dying would make PBs unlikely/impossible, so it cuts out revives. This route still plays safer than the advanced route, namely skipping highly risky strategies like Silph Red Bar. This route is mostly written with goal times around 1:47 or slower in mind.
 - The advanced route is mainly focused toward goal times of 1:45/1:46 or better, where you are likely to have to consistently go for more risky red bar strategies.
+- The WR Route is mainly focused toward goal times of 1:44/1:43, where you must go for risky red bar strategies and have a riskier Agatha and Champ fight.

--- a/docs/gen-1/red-blue/main-glitchless/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/README.md
@@ -3,7 +3,7 @@
 * [Beginner Route](beginner-route/)
 * [Intermediate Route](intermediate-route/)
 * [Advanced Route](advanced-route/)
-* [WR Route](WR-Route)
+* [WR Route](WR-Route/)
 * [Race Route](race-route/)
 
 ## What route do I choose?

--- a/docs/gen-1/red-blue/main-glitchless/WR-Route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/WR-Route/README.md
@@ -1,4 +1,4 @@
-# Pokemon Red Glitchless Advanced Guide
+# Pokemon Red Glitchless WR Route
 
 This guide assumes you know things about the game already.
 

--- a/docs/gen-1/red-blue/main-glitchless/WR-Route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/WR-Route/README.md
@@ -1,0 +1,495 @@
+# Pokemon Red Glitchless Advanced Guide
+
+This guide assumes you know things about the game already.
+
+- [Defensive Damage Ranges](../resources/defensive-ranges.md)
+- [Offensive Damage Ranges](../resources/offensive-ranges.md)
+- Keep this document open at all times: [Advanced HP Strats](../resources/hp-strats.md)
+
+## NIDORAN SPLIT
+
+Rival 1:
+- Tail Whip x1
+- Tackle spam
+
+Route 1
+- KO something that is level 2 or 3
+
+Viridian Mart
+- Buy 3 Poke Balls
+
+Do [Nido Manip](../resources/nido-manip.md)
+
+Do [Triple Extended Manip](../resources/triple-extended/)
+
+## BROCK SPLIT
+
+Weedle Guy:
+- Tail Whip x2
+- Tackle spam
+
+Swap Squirtle and Nido at some point
+- Toss Antidote if you are healing Squirtle before Brock
+
+Pewter Mart
+- Buy 8 Potions
+
+Brock:
+- Swap to Squirtle
+- Bubble x2-3 on Geodude
+- Switch to Nido, then swap back to Squirtle
+- Bubble x2-3 on Onix
+
+## ROUTE 3 SPLIT
+
+Change Options to Set before leaving the gym
+
+BC1:
+- Leer + HA x2 (+ Tackle)
+- Leer + HA (finish with Tackle if you can)
+- Leer + HA + Tackle
+
+*Toss Antidote if healing before Shorts Guy*
+
+Shorts Guy:
+- Leer + HA x2
+- Leer + HA x2
+
+BC2:
+- HA (finish with Tackle if you can)
+- HA x3-4
+- HA x2
+- HA x2 + Tackle
+
+BC3:
+- HA x2
+- HA x3-4 (finish with Tackle if you can)
+
+## MT. MOON SPLIT
+
+Do Route 3 Moon Manip https://pastebin.com/tggXpQRC
+
+Rocket:
+- Rattata
+	- If you have 3+ HA, HA x2 (+ PS)
+	- Otherwise, Leer + HA + Tackle (PS instead of Tackle is a favorable range)
+- Zubat
+	- If you have 3+ HA, HA x3
+	- If you have 2 HA, Leer + HA x2
+	- Otherwise, Leer + HA + Tackle (+ Tackle)
+
+Moon Menu:
+- Use Rare Candy
+- Teach TM12 (Water Gun) in slot 2
+- Use Moon Stone
+- Teach TM01 (Mega Punch) in slot 1
+
+Nerd:
+- MP (finish with WG if you can)
+- MP (PS)
+- MP x2 (lead with HA if you have one. WG if you crit HA, otherwise MP to finish)
+
+## BRIDGE SPLIT
+
+Take the center then get Instant Text then get the hidden Rare Candy
+
+Rival 2:
+- HA x3
+- HA
+- MP
+- MP + HA
+
+BC:
+- MP (+ PS)
+- MP (HA if Caterpie used String Shot)
+
+Lass:
+- MP (+ PS), HA x2
+
+Youngster:
+- MP all
+
+Lass:
+- MP (+ PS)
+- HA x2
+
+Youngster:
+- MP + PS
+
+Rocket:
+- MP all
+
+## MISTY SPLIT
+
+Hiker:
+- Swap WG to slot 1 and use WG
+
+Lass:
+- MP
+- HA x2
+
+Hiker:
+- WG
+- WG
+- MP (+ PS)
+- WG
+
+Lass:
+- MP
+- HA
+- MP (teach Thrash in slot 1)
+
+Bill Menu:
+- After Bill heal with Potions (see HP strats)
+- Rare Candy
+- Escape Rope
+
+Get Instant Text again
+
+Dig Rocket:
+- Thrash
+
+Goldeen:
+- Thrash
+
+Misty:
+- Thrash
+
+## SURGE SPLIT
+
+Get underground Full Restore
+
+Jr Trainer F:
+- Thrash
+
+Jr Trainer M:
+- Thrash
+
+Boat Rival:
+- HA x2
+- MP
+- Thrash
+
+Vermillion Mart:
+- Sell TM34 and Nugget
+- Buy 3 Repels and 3 Parlyz Heals
+
+Cut Menu:
+- Swap Slot 1 with Repel
+- Teach HM01 (Cut) to Paras
+- Teach TM11 (Bubblebeam) to Nidoking in slot 4
+- Teach TM28 (Dig) to Paras
+
+Do Cans Manip
+
+Surge:
+- Thrash
+
+## FLY SPLIT
+
+Get the Bike Voucher then Dig out and get the Bike
+
+Bike Menu:
+- Swap slot 2 with Bike
+- Teach TM24 (Thunderbolt) to Nidoking in slot 3
+- Use slot 2 Bike
+
+4 Turn Thrash Girl:
+- MP
+- Thrash
+
+BC:
+- BB
+- Thrash
+
+Rock Tunnel: Repel 1 step in
+
+Pokemaniac 1:
+- BB
+- TB
+
+Pokemaniac 2:
+- TB
+
+Oddish Girl:
+- Thrash
+
+Use the 2nd repel some point after this fight and use the 3rd repel on [this](https://gunnermaniac.com/pokeworld?map=82#12/14/S) tile before the next fight
+
+Hiker:
+- BB all
+
+Jr Trainer F:
+- Thrash
+
+Pick up the Max Ether outside of Tunnel
+
+Gambler:
+- BB
+- Thrash
+
+Get the Underground Elixer
+
+Shopping
+- 2nd Floor
+	- Buy TM07
+	- Buy 10 Super Repels
+	- Buy 3 Super Potions
+- 4th Floor
+	- Buy 1 Poke Doll
+- Roof
+	- Buy a Soda Pop
+	- Trade it to the girl for Rock Slide
+	- Buy a Fresh Water
+- 5th Floor
+	- Buy 11 X Accuracy
+	- Buy 3 X Specials
+	- Buy 6 X Speeds
+> If Early Drill buy 9 Super Repels, 12 X Acc, 5 X Speeds
+
+Get HM02 Fly
+
+## FLUTE SPLIT
+
+Fly Menu:
+- Swap slot 2 for TM07
+- Use Super Repel
+- Teach TM48 (Rock Slide) in slot 2
+- Swap slot 3 for X Accuracy
+- Teach HM02 (Fly)
+- Fly to Lavender
+> If Early Drill then swap slot 2 for TM07, use Super Repel, teach TM48 in slot 2, teach TM07 in slot 1, swap slot 2 for X Acc then teach Fly
+
+Rival:
+- TB
+- TB
+- BB
+- Thrash
+> If Early Drill, X Acc then HD x5
+
+Channeler 1:
+- RS x2
+
+Pick up the 2 Elixers
+
+Take Heal Pad
+
+Channeler 2:
+- RS
+
+Channeler 3:
+- RS
+
+Pick up the Rare Candy
+
+Teach TM07 over slot 1 if you haven't already
+
+Ghost Menu:
+- Swap slot 3 for Super Repel
+- Use Poke Doll
+
+Rocket 1:
+- TB all (BB to finish)
+
+Rocket 2:
+- X Acc + HD x2
+
+Rocket 3:
+- TB
+- TB
+- Thrash (or TB x2 if Early Drill)
+
+Get the Poke Flute
+
+## KOGA SPLIT
+
+Fly to Celadon and take the center, then Bike to Silph
+
+Go to floor 5 and pick up the hidden Elixer
+
+Rocket:
+- X Acc + HD
+> Parlyz Heal immediately if Glare
+- Use Thrash instead if skipping Silph bar and you didn't do Early Drill
+
+Rival:
+- X Acc + X Speed
+> Use HP strats to see how to setup silph red bar from here
+- HD everything except BB Growlithe (or RS Growlithe if skipping silph bar and you did Early Drill)
+
+Use Elixer before or during the next fight
+
+Rocket:
+- X Acc + BB
+- HD
+- HD
+
+Giovanni:
+- X Acc + HD
+- HD
+- BB
+- HD
+
+Go to floor 10 and get the Rare Candy and TM26 then Dig out
+
+Bike to Snorlax
+
+Snorlax Menu:
+- Use Super Repel
+- Swap slot 5 for Rare Candy then use Poke Flute
+
+Cycling Road
+- Get the Rare Candy
+- Get the PPUP
+
+Post Cycling Road Menu:
+- Use Super Repel (skip repeling if we only bought 9)
+- Swap slot 4 for TM26
+- Use PPUP on Horn Drill
+- Use slot 4 TM26 teaching EQ over slot 2
+- Bike
+
+Cut the bushes to get to Safari Zone
+- If we bought 9 Super Repels, then Super Repel at the start of safari and yolo two tiles at the end by following [this](https://imgur.com/gallery/JeycmGG) path
+- Otherwise, Super Repel in Zone 3
+
+Dig out after getting Surf then Fly to Fuschia and Bike to the gym
+
+Juggler 1:
+- EQ x4
+
+Juggler 2:
+- EQ
+- EQ + TB (+ EQ/BB if TB disable. BB is a range)
+
+Koga:
+- EQ x3
+- Use slot 7 Elixer
+> X Special if X Attack and have an extra, otherwise x-speed if you have an extra
+
+## ERIKA SPLIT
+
+Get Strength then Fly to Pallet Town and walk to the bottom of the water
+
+Pallet Menu:
+- Use Super Repel
+- Rare Candy x3, toggle up 1 to Nido
+- Swap slot 4 for X Speed
+- Teach HM03 to Squirtle
+- Surf
+
+Mansion
+- Get Blizzard then menu
+
+Blizzard Menu:
+- Teach HM04 to Squirtle
+- Teach TM14 (Blizzard) to Nidoking in slot 4
+- Use Super Repel
+
+Skip the Rare Candy
+
+Pick up the Secret Key then Dig out
+
+Bike to the gym
+
+Beauty:
+- Blizz
+
+Erika:
+- EQ
+- Blizz
+- EQ
+
+## BLAINE SPLIT
+
+Fly to Cinnabar
+
+Blaine:
+- X Acc + EQ or Drill if turn 1 super pot
+- HD x3
+
+## SABRINA SPLIT
+
+Dig out and Bike to Sabrina's gym
+
+Sabrina:
+- EQ x4
+
+## GIOVANNI SPLIT
+
+Dig out and Fly to Viridian City and Bike to the gym
+
+Cooltrainer:
+- EQ
+
+Blackbelt:
+- X Acc + HD
+- Blizz
+- HD
+
+Leave the gym, re-enter and use Elixer 1 step in
+
+Note: You need to save at least 1 Blizzard for Agatha's Golbat so play accordingly
+
+Giovanni:
+- EQ x4
+- Blizz Rhydon until you have 2 Blizzard left (EQ after that)
+	- If early Elixer EQ Rhydon once if miss Blizz range
+
+## LORELEI SPLIT
+
+Super Repel + Bike
+
+Rival:
+- X Acc + X Speed + Blizz (+ TB)
+- Blizz
+- TB
+- EQx2
+- HD
+
+Deposit Squirtle and Paras
+> If desperate, also deposit bird to save about 18 seconds.
+
+Lorelei: 
+- Swap to bird turn 1
+- Swap to Nidoking
+- X Acc + HD x5
+- Note: Option to swap Nidoking and bird pre-fight if you want to save 0-0.5s at the cost of being difficult
+
+## BRUNO SPLIT
+
+Use Max Ether on Horn Drill
+
+Bruno:
+- X Acc + HD x5
+
+## AGATHA SPLIT
+
+Use Super Potion
+> If 32 hp or below, can skip heal to save 14 seconds
+
+Agatha:
+- X Speed + EQ
+- Blizz + TB
+- EQ x3
+> if hazed and still have an extra x-item, X Speed or X-Special on Arbok with 25-60 HP or yolo
+
+## LANCE SPLIT
+
+Use Elixer and heal to 127+ HP
+
+Lance:
+- X Special + TB
+- Blizz
+- X Speed + Blizz
+- TB
+- Blizz
+
+## CHAMP SPLIT
+
+Champion:
+- X Acc + X Speed + HDx6
+
+> WA does 21-25, unless X Speed turn 1, then WA does 20-24
+> Sky Attack does 82-97, unless X Speed turn 1 (Sky Attack does 74-87)
+> If Sky Attack turn 1: Drill Pidgeot, X-Speed Alakazam (1/2 to live), HDx5

--- a/docs/gen-1/red-blue/main-glitchless/WR-Route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/WR-Route/README.md
@@ -268,7 +268,7 @@ Rival:
 > If Early Drill, X Acc then HD x5
 
 Channeler 1:
-- RS x2
+- RS x2 (on late drill, swap RS to slot 1)
 
 Pick up the 2 Elixers
 

--- a/docs/gen-1/red-blue/main-glitchless/intermediate-route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/intermediate-route/README.md
@@ -19,9 +19,8 @@
 Rival 1:
 - Tail Whip + spam Tackle
 
-> Check stats on level up after Rival 1
+> Optional: check stats on level up after Rival 1
 > - 10 ATK - Tail Whip x3 on Weedle Guy in forest
-> - 12 ATK - Tail Whip + Tackle x2 on L3 Rat encounter only
 > - 12 DEF is bad defense, expect Geodude & Onix to do more damage (see Defensive Ranges)
 > - 11 SPC is likely bad special (3 hit on Geodude and/or Onix)
 > - 12 SPC is guaranteed good special (2 hit on Geodude & Onix)
@@ -41,7 +40,7 @@ Do [Nido Manip](../resources/nido-manip.md)
 - Pick up the Antidote
 - Pick up the hidden Weedle Guy Potion
 
-> 1-15 Potion before the fight
+> 1-12 Potion before the fight
 
 Weedle Guy:
 - Tail Whip x2, spam Tackle [1-4 Potion]
@@ -151,7 +150,7 @@ If you still need to catch Paras:
 Take the center then get Instant Text then get the hidden Rare Candy
 
 Bridge Rival: Swapping is a lot of timeloss; only consider swap if 2+ Sand-Attacks & you are far ahead of PB
-- Pidgeotto: HA x2 + HA or MP
+- Pidgeotto: HA x2 + HA or MP (Lead MP if you got moon exp)
 - Abra: HA
 - Rat: MP
 - Bulba: MP + HA (finish with MP if Growl)
@@ -247,6 +246,8 @@ Jr Trainer F:
 Jr Trainer M:
 - Thrash
 
+> If 1-6 hp, either potion before boat rival and teach TM11 or potion turn 1 on pidgeotto. Also Note: if you are good pace or simply prefer to get the gentleman candy, you can enter the 4th door from the left while you still have red bar and IT before menuing to potion and teach TM11.
+
 Boat Rival:
 - Pidgeotto:
 	- HA x2 (BB x2 if you have it)
@@ -286,11 +287,11 @@ Use Cut and do Cans Manip
 Surge:
 > If ever confused on Raichu swap to bird or Squirtle, unless you can live hit self
 - Voltorb:
-	- 1-20: Thrash
+	- 1-20: Thrash x1-2
 	- 21-24: HA + BB
 	- 25+: BB x2
 - Pikachu: Thrash
-- Raichu: Thrash
+- Raichu: Thrash x2
 	- Hit self damage:
 		- 14 damage
 		- 9 damage w/ Growl
@@ -347,11 +348,13 @@ Pokemaniac 1:
 Pokemaniac 2:
 - Slowpoke: TB
 
-Oddish Girl: [Parlyz Heal immediately if Stun Spore hits]
-- Oddish: Thrash (or at 18-22 use: TB + Thrash, if asleep Potion at 1-5)
+Oddish Girl:
+- Oddish: Thrash (or at 18-22 use: TB + Thrash, if asleep Potion at 1-5, if stun spore still use Thrash)
 - Bulba: Thrash
 
 Use 2 Repels at some point after this fight and before the next fight
+
+> Use Para Heal in the last repel menu if needed
 
 Hiker:
 - BB x3
@@ -364,7 +367,7 @@ Pick up the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=1#336/97) 
 Gambler: [1-4 Potion turn 1]
 - Growlithe: BB (+ Thrash)
 - Vulpix: Thrash
-> Take note of your HP leaving Gambler
+> Take note of your HP leaving Gambler and note extra money if we did gentleman
 
 HP    | Strategy
 ----- | --------------
@@ -390,7 +393,7 @@ Get the [Underground Elixer](https://gunnermaniac.com/pokeworld?map=121#21/5)
 - 2nd Floor
 	- Buy TM07
 	- Buy 7 Super Repels
-	- Buy 4 Super Potions (**3 on Early Drill**)
+	- Buy 4 Super Potions (**3 on Early Drill** - still 4 if gentleman)
 - 4th Floor
 	- Buy 1 Poke Doll
 - Roof
@@ -399,7 +402,7 @@ Get the [Underground Elixer](https://gunnermaniac.com/pokeworld?map=121#21/5)
 	- Buy a Fresh Water
 - 5th Floor
 	- Buy 11 X Accuracy (**12 on Early Drill**)
-	- Buy 5 X Specials (**4 on Early Drill**)
+	- Buy 5 X Specials (**4 on Early Drill** - still 5 if gentleman)
 	- Buy 3 X Speeds
 
 Get HM02 Fly
@@ -528,7 +531,7 @@ Use your Bike and go west to Snorlax
 
 In the Safari Zone:
 - If needed see [Safari Movement](https://imgur.com/gallery/h9KpU3I)
-- Menu in the 2nd Zone around [this tile](https://gunnermaniac.com/pokeworld?map=217#17/24) to use slot 2 Super Repel (cursor is on items)
+- Menu in the 2nd Zone around [this tile](https://gunnermaniac.com/pokeworld?map=217#17/24) to use slot 3 Super Repel (cursor is on items)
 - If you have zero Potions, pick up [TM40](https://gunnermaniac.com/pokeworld?map=218#19/7) for bag space
 - Pick up the [Teeth](https://gunnermaniac.com/pokeworld?map=219#19/7) and get HM03
 - Exit the Surf house, Dig out of the safari, and Fly back to Fuschia City


### PR DESCRIPTION
I notice that on github the link I put for the red wr route doesn't work when you go from Glitchless Routes --> Red/Blue --> WR Route

I think in the "what route do I choose page" I left out a backslash after "WR-Route"
speedrun-routes/docs/gen-1/red-blue/main-glitchless/
README.md