### PR TITLE
Avoid global installation of docsify-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ A wiki for viewing and editing Pokemon Speedrun routes using GitHub Pages and Do
 Wiki page edits can be suggested on GitHub by navigating through the docs folder and clicking the pencil icon once you find the relevant markdown page, then after making the relevant edit you can submit a pull request by scrolling to the bottom.
 
 ## Development for Site Wrapper Code
-You can test changes to the site's wrapper code in `docs/index.html` locally using Node.JS. Install docsify with `npm install docsify-cli -g` and then run `docsify serve docs` to spin up a local development server.
+You can test changes to the site's wrapper code in `docs/index.html` locally using Node.JS. Run `npx docsify-cli@4 serve docs` to spin up a local development server.


### PR DESCRIPTION
and pin the version to 4.x to avoid breaking changes

-----

This makes it so that one can edit the documents and live preview locally without having to install docsify-cli globally. It also always uses the 4.x version in case a 5.x would be released that would no longer work the same way...