### PR TITLE
Create Classic Intermediate Route

### DIFF
--- a/docs/gen-1/red-blue/main-glitchless/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/README.md
@@ -16,6 +16,10 @@
 # Red Any% Glitchless (Classic) Routes
 
 * [Classic Beginner Route](classic-beginner-route/)
+* [Classic Intermediate Route](classic-intermediate-route/)
 * [Classic Advanced Route](classic-advanced-route/)
   - Red Classic is the manipless category of gen 1.
   - Classic bans RNG manips, instant text, and the poke doll skip.
+  - The beginner route is best if you are brand new to Red Speedruns.
+  - The intermediate route is best to use as your introductory route if you are now familiar with red speedruns either because you completed a few runs with the beginner classic route or if you have already ran glitchless. Either way you will need to check stats of your nido and utilize the red helper program to flex a few different strategies to play safely and optimally.
+  - The advanced route is mainly focused toward goal times of 1:56/1:57 or better, where you are likely to have to consistently go for more risky red bar strategies.

--- a/docs/gen-1/red-blue/main-glitchless/classic-advanced-route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/classic-advanced-route/README.md
@@ -537,14 +537,14 @@ Silph Rocket #1:
 
 Get the Card Key.
 
-  SPC  |  HP Pidg Turn 3  | Gyarados (+1 Spec and +1 Speed)
------- | ---------------- | ----------------------------------------
-   0   |       107        |  <details><summary>0 SPC</summary><br><img src="https://i.imgur.com/WwVrfuc.png" width="250"></details> 
-  1-3  |       105        |  <details><summary>1-3 SPC</summary><br><img src="https://i.imgur.com/arC0Kuk.png" width="250"></details> 
-  4-6  |       101        |  <details><summary>4-6 SPC</summary><br><img src="https://i.imgur.com/8XjJLpp.png" width="250"></details> 
-  7-8  |        99        |  <details><summary>7-8 SPC</summary><br><img src="https://i.imgur.com/TRXiqr7.png" width="250"></details> 
-  9-12 |        95        |  <details><summary>9-12 SPC</summary><br><img src="https://i.imgur.com/sCrrhh6.png" width="250"></details> 
- 13-15 |        93        |  <details><summary>13-15 SPC</summary><br><img src="https://i.imgur.com/gp5MWiD.png" width="250"></details> 
+  SPC  |    Gyarados (+1 Spec and +1 Speed)
+------ |  ----------------------------------------
+   0   |   <details><summary>0 SPC</summary><br><img src="https://i.imgur.com/WwVrfuc.png" width="250"></details> 
+  1-3  |   <details><summary>1-3 SPC</summary><br><img src="https://i.imgur.com/arC0Kuk.png" width="250"></details> 
+  4-6  |   <details><summary>4-6 SPC</summary><br><img src="https://i.imgur.com/8XjJLpp.png" width="250"></details> 
+  7-8  |   <details><summary>7-8 SPC</summary><br><img src="https://i.imgur.com/TRXiqr7.png" width="250"></details> 
+  9-12 |   <details><summary>9-12 SPC</summary><br><img src="https://i.imgur.com/sCrrhh6.png" width="250"></details> 
+ 13-15 |   <details><summary>13-15 SPC</summary><br><img src="https://i.imgur.com/gp5MWiD.png" width="250"></details> 
 
 Silph Rival:
 - Pidgeot: X Acc + X Speed (+ X Special) + HD

--- a/docs/gen-1/red-blue/main-glitchless/classic-advanced-route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/classic-advanced-route/README.md
@@ -106,7 +106,7 @@ Menu:
 - Potion to full HP
 - Toss Antidote if you haven't already
 
-Shorts Guy: [1-17 Potion on Rat]
+Shorts Guy: 
 - Rat:
 	- Leer + HA x2
 - Ekans:
@@ -300,7 +300,8 @@ Vermilion Mart
 - Buy 3 Repels
 - Buy 3+ Parlyz Heals
 
-Enter the S.S. Anne.
+Boat Menu:
+- Slot 4 - teach TM11 over slot 4 PS or slot 2 Tackle
 
 Boat Rival:
 - Pidgeotto: HA + HA/BB
@@ -317,7 +318,6 @@ Exit the boat and head towards Surge's gym.
 Trade for Dux in [this house](https://gunnermaniac.com/pokeworld?map=1#235/193) if you still need something to learn Cut.
 
 Cut Menu:
-- Slot 4 - teach TM11 over slot 4 PS or slot 2 Tackle
 - Swap Potion down 4 with Repels
 - Down 2 - teach HM01 to Paras/Oddish/Dux
 - Up 3 - Teach TM28 to Paras or Squirtle
@@ -364,6 +364,8 @@ Bug Catcher (at 16-19 HP: TB x2 and BB x2):
 | 13-15  | 24 - 30                      | 31 - 37         |  38 - 51                |
 | 6-12   | 26 - 32                      | 33 - 40         |  41 - 51                |
 | 0-5    | 2nd Slowpoke: BB + TB @27-35 |                 |                         |
+
+> if desperate for red bar utilize the red helper defensive ranges to set up red bar as needed
 
 Repel one step into Rock Tunnel.
 
@@ -449,7 +451,7 @@ Grunt Menu:
 - Down 4 teach TM07 Horn Drill over slot 1 Thrash
 
 Right Grunt:
-> X Acc on Sandshrew if you can take a Slash crit, otherwise on Ekans
+> X Acc on Sandshrew is faster, but judge risk based on defensive ranges
 - Ekans: (X Acc) IB
 - Sandshrew: (X Acc) IB
 - Arbok: HD
@@ -459,7 +461,7 @@ Left Grunt:
 - Ekans: IB
 - Sandslash: IB
 
-Heal to ~11+ HP for Giovanni if needed.
+Heal before Giovanni if needed.
 
 Giovanni:
 > X Acc Rhyhorn if ~21+ HP
@@ -535,9 +537,18 @@ Silph Rocket #1:
 
 Get the Card Key.
 
+  SPC  |  HP Pidg Turn 3  | Gyarados (+1 Spec and +1 Speed)
+------ | ---------------- | ----------------------------------------
+   0   |       107        |  <details><summary>0 SPC</summary><br><img src="https://i.imgur.com/WwVrfuc.png" width="250"></details> 
+  1-3  |       105        |  <details><summary>1-3 SPC</summary><br><img src="https://i.imgur.com/arC0Kuk.png" width="250"></details> 
+  4-6  |       101        |  <details><summary>4-6 SPC</summary><br><img src="https://i.imgur.com/8XjJLpp.png" width="250"></details> 
+  7-8  |        99        |  <details><summary>7-8 SPC</summary><br><img src="https://i.imgur.com/TRXiqr7.png" width="250"></details> 
+  9-12 |        95        |  <details><summary>9-12 SPC</summary><br><img src="https://i.imgur.com/sCrrhh6.png" width="250"></details> 
+ 13-15 |        93        |  <details><summary>13-15 SPC</summary><br><img src="https://i.imgur.com/gp5MWiD.png" width="250"></details> 
+
 Silph Rival:
 - Pidgeot: X Acc + X Speed (+ X Special) + HD
-- Gyarados: (X Special) HD
+- Gyarados: (X Special) HD (or TB if it KOs and HD the rest)
 - Growlithe: RS
 - Alakazam: HD
 - Venusaur: HD

--- a/docs/gen-1/red-blue/main-glitchless/classic-intermediate-route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/classic-intermediate-route/README.md
@@ -1,0 +1,865 @@
+# Pokemon Red Glitchless Classic Intermediate Guide 
+- This route is a natural next step for runners who have completed a run or two with the beginner route 
+- This route also aims to be the introductory route for runners of red glitchless and runners interested in learning optimal strats right away.
+- For movement and menus watch any recent leaderboard time.
+
+> Note: This route plays safely by default with 3-4 Speed DV by getting the extra 
+
+- [Resources - Pokémon Red/Blue](https://www.speedrun.com/pkmnredblue/resources)
+	- TOOLS: Download "Red Classic Helper"
+	- SAVES: Download "Any% Glitchless (Classic)"
+
+<details><summary>Carbos Strategies for this route <i>(click to unfold)</i></summary>
+
+Speed DV | Strategy used                         | Alternate strategies         |   |  
+-------- | ------------------------------------- | ---------------------------- | - | -
+0        | 2 Carbos + X Speed Sabrina's Mr. Mime | 2 Candies + 3 Carbos
+1        | 1 Carbos + X Speed Sabrina's Mr. Mime | 2 Candies + 3 Carbos
+2        | X Speed Sabrina's Mr. Mime            | 2 Candies + 2 Carbos
+3        | (1 Candy + 3 Carbos)                  | X Speed Sabrina's Mr. Mime   | 2 Candies + 2 Carbos
+4        | (1 Candy + 2 Carbos)                  | X Speed Sabrina's Mr. Mime   | 2 Candies + 1 Carbos
+5        | 3 Carbos                              | X Speed Sabrina's Mr. Mime   | 1 Candy + 2 Carbos | 2 Candies
+6        | 2 Carbos                              | 1 Candy + 1 Carbos           | 2 Candies
+7        | 2 Carbos                              | 1 Candy
+8        | 1 Carbos                              | 1 Candy
+9-10     | -
+11       | (2 Carbos)                            | -                            | 1 Candy + 1 Carbos
+12       | (2 Carbos)                            | -                            | 1 Candy
+13       | 1 Carbos                              | -                            | 1 Candy
+14-15    | -
+
+</details>
+
+- This guide will always offer Carbos + extra candy strategies to avoid being outsped by Sabrina's Zam (which forces us to set up a very risky X-Speed on Mr. Mime who is 1/3 to use confuision 1/3 to use barrier).
+  - Carbos strategies that are optional have the Speed DVs in () the DVs that have optional carbos pickups are (3-4) and (11-12).
+  - 3 SPD --> 3 Carbos + extra candy in mansion
+  - 4 SPD --> 2 Carbos + extra candy in mansion
+  - 11-12 SPD --> 2 Carbos to outspeed Agath's 1st Gengar this timeloss gives us a less risky Agatha fight (we still heal, but only risk her 2nd Gengar that knows fewer scary moves)
+
+- This guide avoids higher risk red bar strategies by default, but they are available for runs that fall too far behind. Note that Flute-to-End times under 44 minutes are achievable in classic with solid execution and sub 11:00 Fly split is achievable without fly red bar.
+
+- If not going for a top leaderboard time it is suggested to use one of the safer strats involving extra candies instead of X Speed Sabrina strats.
+- See [this pastebin explanation](https://pastebin.com/sEWrd0v8) and the [complete speed chart](https://imgur.com/MpKBIb1) for more information.
+
+### Glossary
+
+- Moves: HA = Horn Attack, BB = Bubblebeam, WG = Water Gun, TB = Thunderbolt, PS = Poison Sting, HD = Horn Drill, IB = Ice Beam, RS = Rock Slide
+	- (+ MOVE): A situational move used to finish off a pokemon when a damage range is missed
+- Livesplits has an autosplitter built in for Pokemon Red
+	- Activate within “edit splits” and then go into settings to set your preferences for where you want to split
+- Hard Resetting **during** a Classic speedrun is not allowed
+	- If you ever take a safety save into a death during the run, then you can only **soft reset** using **A + B + Start + Select** held at once
+	- Hard Resetting the console means that RNG Manipulation is technically possible and this is banned from Classic
+
+### Before you start
+
+- Clear any existing save file by pressing **Up + B + Select** on the game title screen
+- Hard Reset (set palette with Up + B - optional to give full visibility in Rock Tunnel), **hard resetting is required before each attempt on emulator**
+- Set your options to fast text and animations OFF
+
+## NIDORAN SPLIT
+
+Optional: Pick up the PC Potion.
+
+Rival 1:
+- Tail Whip + spam Tackle
+
+Route 1
+- Spam Tackle to faint one encounter that is L2 or L3
+
+Viridian Mart
+- Buy 7 Poke Balls
+
+- Catch a L3 or L4 Nidoran♂ and give it a one-character name
+	- L3 Nido: Tackle once before throwing Poke Balls
+	- L4 Nido: just throw Poke Balls
+	- L5 Spearow: just throw Poke Balls, since it outspeeds us
+
+| Time-Based DSUM                                         | Step-Based DSUM                                         |
+| ------------------------------------------------------- | ------------------------------------------------------- |
+| <img src="https://i.imgur.com/RBD6c2T.jpg" width="650"> | <img src="https://i.imgur.com/LSGYzXO.png" width="220"> |
+
+## BROCK SPLIT
+
+- Get the hidden Tree Potion.
+- Get the Antidote.
+- Get the hidden Potion.
+
+Weedle Guy:
+- Tail Whip x2, spam Tackle [1-6 Potion]
+
+Swap Squirtle and Nido at some point.
+
+| HP   | Healing Strategy          |
+| ---- | ------------------------- |
+| 1-7  | Potion                    |
+| 8-10 | Potion if PSN             |
+| 11+  | Don't Heal                |
+
+Brock:
+- Swap to Squirtle
+- Spam Bubble on Geodude
+- Switch to Nido, then swap back to Squirtle
+	- If Bide: TW x2
+- Spam Bubble on Onix	
+
+## ROUTE 3 SPLIT
+
+Pewter Mart
+- Change Options Battle Style to Set two steps into the mart
+- Buy 8 Potions
+
+Bug Catcher 1:
+- Caterpie: Leer + HA x2 (+ Tackle)
+- Weedle: Leer + HA + Tackle (or HA) (Potion if it heals near 20)
+- Caterpie: Leer + HA + Tackle (or HA)
+
+Menu:
+- Potion to full HP
+- Toss Antidote if you haven't already
+
+> Ignoring 1/39 rolls below, note that Rat QA crit is about the same as QA @-1 and we should heal to live Rat QA
+
+| DEF DV   | Rat QA    |
+| -------- | --------- |
+|   0-2    |  11 [17]  |
+|   3-12   |  10 [16]  |
+|  13-15   |   8 [14]  |
+
+Shorts Guy: 
+- Rat: 
+	- Leer + HA x2
+- Ekans: 
+	- Leer
+	- Swap HA to slot 1 + HA x2
+
+> After Leer is used the inputs required to swap = Select → Up → Select → A
+
+Bug Catcher 2:
+- Weedle: HA + HA or Tackle
+- Kakuna: HA x2-3 + Tackle x1-2
+- Caterpie: HA x2
+- Metapod: HA x2-3 + Tackle x1-2
+
+Bug Catcher 3: (if <4 HAs, save an HA on the Caterpie even if it takes an extra turn)
+- Caterpie: HA x2
+- Metapod: HA x3-5 + Tackle spam
+
+Catch a flyer:
+- L8 Pidgey use HA or use Leer + Tackle if 0 HAs remain.
+- Tackle then toss a Ball at any other flyer
+	- Can PS after Tackle if Tackle did much less than half HP damage
+
+Use the Pokemon Center to heal before entering Mt. Moon.
+
+## MT. MOON SPLIT
+
+Enter Mt. Moon.
+
+> Note: Follow the alternate strategy of getting TM12 Water Gun and fighting the hiker is easier if you are using this as an introductory route.
+
+<img src="https://i.imgur.com/qR93hZO.png">
+
+Get TM12 if on Hiker Strats.
+
+Fight the Super Nerd:
+- Magnemite: HA x2 + HA/PS
+- Voltorb: HA x2 + PS
+
+Get **Rare Candy** + **Escape Rope**.
+
+Fight the lass:
+- Oddish: HA x2-3
+- Bellsprout: HA x2
+
+If on Hiker Strats, Menu:	
+- Use TM12 to teach Nidorino Water Gun over slot 3 Leer
+
+Optional Hiker:
+- WG spam
+
+Get the **Moon Stone**.
+
+Menu before Rocket:
+- Use Moon Stone on Nidorino
+
+Moon Rocket:
+- Rattata: HA + PS
+- Zubat: HA x2 (can Potion if confused)
+
+Super Nerd:
+- Grimer: HA x2
+- Voltorb: HA + HA/PS
+- Koffing: HA x2 + PS
+
+Get the **Helix Fossil** and exit Mt. Moon.
+
+## BRIDGE SPLIT
+
+Take the Center.
+
+Pick up the hidden Rare Candy.
+
+Bridge Rival:
+- Pidgeotto: HA x3 (+ PS)
+- Abra: HA
+- Rattata: HA + PS
+- Bulbasaur: HA x2 (+ PS or HA if Growl)
+
+#1 - Bug Catcher:
+- Caterpie: HA + PS
+- Weedle: HA (+ PS)
+
+#2 - Lass:
+- Pidgey: HA + PS
+- Nidoran♀: HA x2
+
+#3 - Youngster:
+- Rattata: HA (+ PS)
+- Ekans: HA + PS or HA
+- Zubat: HA (+ PS)
+
+Menu **whenever you reach L21**:
+- Use the two Rare Candies on Nido
+- Teach Thrash over Tackle (slot 2) or over Poison Sting (slot 4) if no Paras
+- Swap Thrash to slot 1 the next fight (Select → Down → Select → A)
+
+#4 - Lass:
+- Pidgey: Thrash or HA + PS
+- Nidoran♀: Thrash or HA x2
+
+#5 - Jr. Trainer♂:
+- Mankey: Thrash or HA + HA/PS
+
+Bridge Rocket:
+- Ekans: Thrash
+- Zubat: Thrash
+
+## MISTY SPLIT
+
+If you have WG, do Bottom Hiker, otherwise do Top Hiker.
+
+<table>
+<tr><td>
+
+Top Hiker:
+- Machop: HA + PS or Thrash
+- Geodude: Thrash x3
+
+</td><td>
+
+Bottom Hiker:
+- Onix: WG
+
+</td></tr>
+</table>
+
+Lass:
+- Nidoran♂: Thrash
+- Nidoran♀: Thrash
+
+<img src="https://i.imgur.com/wwwP9mH.png" height=165>
+
+Jr. Trainer♂ (do not fight the two-tile vision Hiker):
+- Rattata: Thrash
+- Ekans: Thrash
+
+Lass:
+- Oddish: Thrash
+- Pidgey: Thrash
+- Oddish: Thrash
+
+Enter Bill's House and NOTE: 
+- Get S.S. Ticket from Bill
+- | SPD DV | Healing Strategy                  |
+  | ------ | --------------------------------- |
+  | 0-10   | Center                            |
+  | 11-12  | Center or Potion to near full hp  |
+  | 13+    | Potion to ~70+ HP or Center       |
+- Use Escape Rope
+
+Enter Misty's gym.
+
+Jr. Trainer♀:
+- Goldeen: Thrash x2
+
+> Menu and potion again if needed (+ Optional Save)
+
+Misty:
+- Staryu: Thrash x1
+- Starmie: Thrash x2-3+
+
+## SURGE SPLIT
+
+Dig Rocket:
+- Machop: Thrash x1-2
+- Drowzee: Thrash x1
+
+Get TM28 Dig from the Rocket. And optionally pick up the hidden full restore to sell in Vermillion.
+
+> If you fought hiker, faint one encounter if you see it.
+
+Oddish DSUM
+- Ignore this if you already have a Paras
+- If you have no Paras and have a Pidgey, then weaken an Oddish with Tackle and throw Poke Balls
+- If you have no Paras but have a Spearow, then trade Spearow for DUX the Farfetch'd later on unless you happen to encounter an Oddish, in which case, Tackle and throw Poke Balls
+
+| Time-based (repeat last two columns of the given row) | Step-based                                  |
+| ----------------------------------------------------- | ------------------------------------------- |
+| <img src="https://i.imgur.com/Fm7I10i.png">           | <img src="https://i.imgur.com/fHtG2mb.png"> |
+
+Jr. Trainer♀:
+- Pidgey x3: Thrash
+
+Jr. Trainer♂:
+- Spearow: Thrash
+- Raticate: Thrash
+
+Enter the Mart.
+
+Vermilion Mart
+- Sell all Poke Balls
+- Sell TM34
+- Sell Nugget
+- Buy 3 Repels
+- Buy 4+ Parlyz Heals
+
+Menu before or after entering the S.S. Anne:
+- Slot 4 - teach TM11 over slot 4 PS or slot 2 Tackle
+- Potion if Pidgeotto can KO you with QA.
+
+Boat Rival: 
+- Pidgeotto: HA + BB (Swap on bird after sand if it can KO you - use a turn to potion while HM-user is out)
+- Raticate: BB x2 (Potion if needed; swap if sand attacked and KO'd bird)
+- Kadabra: Thrash x1 (or HA Kadabra and Potion turn 1 on Ivy if vine whip KOs)
+- Ivysaur: Thrash x2
+
+Get HM01 from the captain.
+
+Optional safety: Fight the Gentleman in [this room](https://gunnermaniac.com/pokeworld?map=96#21/11) with Thrash and get the Candy.
+
+> The Optional Candy may be used in either cut menu or delayed to EQ Menu.
+> 
+> Using the candy in cut menu is beneficial for low HP and/or low ATK (for Voltorb Thrash range) and/or 0-5 SPC (for 2nd slowpoke TB range).
+> 
+> Very slow safe strat - delaying the candy to EQ Menu is beneficial for below 3 SPD to open up strategies to outspeed Sabrina's Zam without needing to X-Speed Mr. Mime, but this strategy is not standard in this route and changes the position of rare candy in your menus.
+
+Exit the boat and head towards Surge's gym.
+
+Trade for Dux in [this house](https://gunnermaniac.com/pokeworld?map=1#235/193) if you still need something to learn Cut.
+
+Cut Menu:
+- Swap Potion down 4 with Repels
+- Down 2 - teach HM01 to Paras/Oddish/Dux
+- Up 3 - Teach TM28 to Paras or Squirtle
+- Cut the tree and enter Surge’s gym
+
+Surge Trash Cans Puzzle
+
+<img src="https://i.imgur.com/DgQyq4a.jpeg" >
+
+- Save the game after finding the first can (unless the first switch is can #2 or #4, then simply take a 1/4 guess and move onto the next can)
+- All other cans are 50/50, so if you don’t get the the second switch first try, then you soft reset and know the second switch is in the top left can (can #5)
+
+Surge:
+- Voltorb: Thrash or BB + BB/HA
+- Pikachu: Thrash
+- Raichu: Thrash x2
+
+## FLY SPLIT
+
+Get TM24 Thunderbolt and exit the gym.
+- Get the Bike Voucher, and Dig out to Cerulean City
+- Get the Bike from the Bike Shop and exit the shop
+
+Menu:
+- Swap slot 2 Helix Fossil down 6 with Bicycle
+- Up 1 - Teach TM24 Thunderbolt over slot 3 (Leer or WG)
+- Slot 2 - Get on the bike, cut both trees to head east into Route 9
+
+4-Turn Thrash Girl:
+- Oddish: Thrash or HA + TB 
+- Bellsprout: Thrash
+- Oddish: Thrash
+- Bellsprout: HA (if Thrash ends)
+	- Swap and swap back if you can't hit yourself
+	- HA + TB Oddish is generally better than swapping if you can take Absorb
+
+Bug Catcher (at ~16-19 HP: TB x2 and BB x2):
+- Caterpie: TB (or BB if it KOs)
+- Weedle: Thrash
+- Venonat: Thrash x1-2
+
+Ignore the following unless in need of ~45 seconds of timesave 
+- please note that a well executed fly split can be done in 10:45 or better with no red bar
+
+| SPC DV | 1st Slowpoke BB + TB         | Cubone: TB + BB | 1st Slowpoke BB x2 + TB |
+| ------ | ---------------------------- | --------------- | ----------------------- |
+| 13-15  | 24 - 30                      | 31 - 37         |  38 - 51                |
+| 6-12   | 26 - 32                      | 33 - 40         |  41 - 51                |
+| 0-5    | 2nd Slowpoke: BB + TB @27-35 |                 |                         |
+
+Repel one step into Rock Tunnel.
+
+Pokemaniac #1:
+- Cubone: BB
+- Slowpoke: TB
+
+Pokemaniac #2:
+- Slowpoke: TB
+
+Oddish Girl:
+- Oddish: Thrash x1-2
+- Bulbasaur: Thrash
+	- If paralyzed, wait until the next Repel menu to use a Parlyz Heal
+
+Repel twice before the next fight.
+
+Hiker:
+- Geodude: BB
+- Geodude: BB
+- Graveler: BB
+
+> Heal if QA KOs you and pace allows it
+
+Jr. Trainer♀:
+- Meowth: Thrash
+- Oddish: Thrash
+- Pidgey: Thrash
+
+Pick up the hidden Max Ether.
+
+Gambler (Potion turn 1 if you're likely to be KO'd):
+- Growlithe: BB + Thrash or Thrash
+- Vulpix: Thrash
+
+Underground: pick up the hidden Elixer.
+
+**Celadon Mart**
+
+> Note that we would buy 3 X-Specials for Silph Bar, but this guide does not reccomend silph bar;
+>
+> proper shopping for silph bar would be displayed in the Red Helper by checking off "buy X Specs" in Options.
+
+2F - Clerk on the left hand side
+- Buy 10 Super Repels
+- Buy 4 Super Potions
+
+6F - Rooftop Vending Machine
+- Buy 1 Soda Pop
+- Buy 2 Fresh Water
+- Give the Soda Pop to the girl first in exchange for TM48 Rock Slide and then one Fresh Water for TM13 Ice Beam
+
+5F - Clerk on the left hand side
+- Buy 13 X Accuracy
+- Buy 1 X Special  
+- Buy 6+ X Speed
+
+Take the elevator to the first floor.
+
+Fly Menu:
+- Swap slot 2 S.S. Ticket, down 12 with X Accuracy
+- Down 3 teach HM02 Fly to bird
+- Up 4 to place cursor on TM13
+- Fly to Celadon (down 1)
+- Teach TM13 Ice Beam to Nidoking over slot 4
+- (Use slot 3 potion) only if QA from Rat KOs (under ~10 hp)
+- Bike to the Game Corner
+
+## HIDEOUT SPLIT
+
+Poster Grunt:
+- Raticate: Thrash x1-2
+- Zubat: Thrash
+
+Lift Key Rocket:
+- Koffing: Thrash x2 (if no Thrashes or 8+ SPC: IB + TB)
+- Zubat: Thrash or TB
+
+Get the Lift Key, the Rare Candy, and TM07.
+
+Take the elevator to B4F.
+
+Grunt Menu:
+- Swap slot 3 Potion, down 6 with Super Repel
+- Down 3 teach TM48 Rock Slide over slot 2
+- Use slot 3 Super Repel
+- Down 3 swap Helix Fossil down 8 with X Speed
+- Down 4 teach TM07 Horn Drill over slot 1 Thrash
+
+Right Grunt:
+> X Acc on Sandshrew if you can take a Slash crit, otherwise on Ekans
+- Ekans: (X Acc) IB
+- Sandshrew: (X Acc) IB
+- Arbok: HD
+
+Left Grunt:
+- Sandshrew: IB
+- Ekans: IB
+- Sandslash: IB
+
+Heal to ~11+ HP for Giovanni if needed.
+
+Giovanni:
+> X Acc Rhyhorn if ~21+ HP
+- Onix: (X Acc) IB
+- Rhyhorn: (X Acc) IB
+- Kangaskhan: HD
+
+Pick up Silph Scope, dig out, fly to Lavender Town.
+
+## FLUTE SPLIT
+
+Lavender Rival:
+
+| HP    | Healing Strategy          |
+| ----- | ------------------------- |
+| 1-9   | Potion turn 1             |
+| 10-19 | X Acc Growlithe           |
+| 20+   | X Acc turn 1              |
+
+> X Accless Alternative (only if 7+ SPC): IB, TB, RS, RS, IB (93.6% @ 7-9 SPC)  
+> [ IB(+TB) Growlithe @13+ SPC; but must TB Pidgeotto if only 2 IB were leftover ]
+
+- Pidgeotto: (X Acc) IB
+- Gyarados: TB
+- Growlithe: (X Acc) HD
+- Kadabra: HD
+- Ivysaur: HD
+
+
+Channeler #1:
+- Gastly: RS
+- Gastly: RS
+
+Get both Elixers (visible and hidden). Take the heal-pad.
+
+Channeler #2:
+- Gastly: RS
+
+Channeler #3:
+- Gastly: RS
+
+Cubone's Mother:
+- Marowak: IB
+
+Rocket #1:
+- Zubat: IB
+- Zubat: IB
+- Golbat: IB
+
+Rocket #2:
+- Koffing: X Acc + HD
+- Drowzee: HD
+
+Rocket #3:
+- Zubat: IB
+- Rattata: IB
+- Raticate: IB x1-2
+- Zubat: IB
+
+Get the Poke Flute from Mr. Fuji.
+
+## KOGA SPLIT
+
+Walk out of his house, then Fly to Celadon.
+
+Take the center.
+
+Get the hidden tree Elixer.
+
+Silph Rocket #1:
+- Arbok: X Acc + HD
+	- If paralyzed by Glare, use Parlyz Heal immediately in fight
+
+Get the Card Key.
+
+Silph Rival:
+- Pidgeot: X Acc + X Speed + HD
+- Gyarados: HD
+- Growlithe: RS
+- Alakazam: HD
+- Venusaur: HD
+
+HP   | Strat
+---- | --------------------------------------------------------
+1-79 | Use slot 7 Max Ether on Horn Drill before the next fight
+80+  | Use Max Ether turn 2 on Cubone or turn 1 on Drowzee
+
+Silph Rocket #2:
+- Cubone: X Acc + (Max Ether if hit under 80) + HD
+- Drowzee: (Max Ether) HD
+- Marowak: IB
+
+Giovanni:
+- Nidorino: X Acc + HD
+- Kangaskhan: HD
+- Rhyhorn: IB 
+- Nidoqueen: HD
+
+Take the elevator to 10F.
+
+> 3, 5 SPD DV: get the Silph Carbos and use it on Nido on the bike menu (cursor will be on your Dig-User)
+
+Get TM26 and Rare Candy and Dig out.
+
+Bike west to Snorlax.
+
+Menu:
+- Use slot 3 Super Repel
+- Down 1 swap Parlyz Heal down 11 with Rare Candy
+- Go down 2 use Poke Flute
+
+Get Rare Candy and PPUP.
+
+EQ Menu
+
+- Use slot 3 Super Repel
+- Down 1 use Rare Candy x2 (2 are still left)
+- Down 1 swap HM01 down 14 with TM26
+- Down 1 to use PP UP on slot 1 Horn Drill
+- Teach slot 5 TM26 Earthquake over slot 2 Rock Slide
+
+Get on the bike and cut both trees to enter the Safari Zone.
+
+SAFARI ZONE
+- Get the Carbos if 0, (3-4), 5-7, or (11-12) SPD DV 
+- Super Repel at the start of zone 3 (and use the carbos ON NIDO if you have it, cursor is on Cut-User)
+- Get the Gold Teeth
+- Get HM03 and exit the house
+- Use Dig
+- Fly back to Fuschia City (down 2)
+
+Bike to Koga’s gym.
+
+Juggler #1:
+- Drowzee: EQ
+- Drowzee: EQ
+- Kadabra: EQ
+- Drowzee: EQ
+
+> If low on hp, optional Potion to live confusion from Hypno.
+
+Juggler #2:
+- Drowzee: EQ
+- Hypno: EQ (+ TB)
+
+Koga:
+- Koffing: EQ
+- Muk: EQ
+- Koffing: EQ
+- Weezing: use slot 6 Elixer, then stall with Poke Flute or X Speed until Self Destruct
+
+> Ideally Nidoking has 0-5 HP, which guarantees red bar now to Bruno  
+> If HP is high enough consider early Erika to stall for a hit
+
+## GYM RUSH
+
+> The order presented in this route is (1) Blaine, (2) Sabrina, (3) Erika  
+> Warning: Be mindful of which pokemon your cursor is on!
+
+## MANSION
+
+Exit Koga's gym.
+- If you have 0-1, (3-4), 5-8, (11-12), 13 SPD DV then **use all slot 4 Rare Candies now** to make room for the Mansion Carbos.
+
+Bike to the Warden's house to get HM04.
+- Exit house
+- Fly to Pallet Town
+
+Surf Menu:
+- Use Super Repel
+- Teach HM03 Surf to Squirtle (over slot 2 Tail Whip if Squirtle already knows Dig)
+- Surf to Mansion
+
+> Get the Carbos if 0-1, (3-4), 5-8, (11-12), 13 SPD DV
+
+<table>
+<tr><td>
+
+If not getting the Carbos:
+- Down 1 teach HM04 Strength to Squirtle over Tackle
+- Scroll up to use Super Repel
+- Down 1 place cursor on Rare Candy
+
+</td><td>
+
+If getting the Carbos, pick it up then:
+- Teach HM04 Strength to Squirtle over Tackle
+- Use Carbos **on Nidoking**
+- Use Super Repel
+- Scroll to the bottom of the bag (leave the cursor on Cancel)
+
+</td></tr>
+</table>
+
+- Get the visible Rare Candy.
+- Only if 3-4 SPD DV get the hidden rare candy (unless you skipped the carbos and plan to X-Speed Mime).
+- Carefully use all remaining Rare Candies **on Nidoking**
+- Pick up the Secret Key and Dig out
+
+## BLAINE
+
+Fly to Cinnabar Island (down 2).
+
+- Blaine’s gym puzzle: A B B B A B
+
+Blaine:
+- Growlithe: X Acc + EQ (HD if turn 1 super pot and remember to EQ Viridian Rival's Zam)
+- Ponyta: HD
+- Rapidash: HD
+- Arcanine: HD
+
+Dig out of Blaine’s gym.
+
+## SABRINA
+
+Bike to Sabrina’s gym.
+
+Sabrina:
+- Kadabra: EQ
+- Mr. Mime: (X Speed), EQ (+TB)
+- Venomoth: EQ
+- Alakazam: EQ
+
+Take the teleporter pad and then use Dig.
+
+## ERIKA
+
+Bike to Erika’s gym.
+
+Beauty:
+- Exeggcute: IB
+
+Erika:
+- Victreebel: IB
+- Tangel: IB
+- Vileplume: IB
+
+Exit Erika's gym.
+
+## GIOVANNI SPLIT
+
+Fly to Viridian City (up 1) and bike to Giovanni's gym.
+
+Cooltrainer♂:
+- Rhyhorn: IB
+
+Blackbelt:
+> 0-4 ATK: X Acc + HD if you have an extra X Acc
+- Machoke: EQ (+ TB)
+- Machop: EQ (TB if Leer w/5+ SPC)
+- Machoke: EQ (+ TB)
+
+Exit and re-enter the gym.
+
+> If you somehow used extra EQs or IBs, Elixer now
+
+Giovanni:
+- Rhyhorn: IB
+- Dugtrio: IB
+- Nidoqueen: EQ
+- Nidoking: EQ
+- Rhydon: IB x1-2
+
+## LORELEI SPLIT
+
+Walk out of Giovanni's gym and menu:
+- Use a Super Repel
+- (Use Elixer if you skipped the PPUP)
+- Bike
+
+Viridian Rival:
+- Pidgeot: X Acc + X Speed + TB x2 (IB x2 if early Elixer)
+- Rhyhorn: IB
+- Gyarados: TB
+- Growlithe: HD (EQ if early Elixer)
+- Alakazam: HD (**EQ** if early Elixer or only 1 HD left from turn 1 super pot on Blaine)
+- Venusaur: HD
+
+Last Boulder Menu:
+- Use Strength
+- Use Elixer (if you didn't use it early)
+- Use Super Repel
+- Bike
+
+Optional: Pick up the hidden [Full Restore](http://gunnermaniac.com/pokeworld?map=194#26/7) 
+
+Indigo Plateau
+- Deposit Squirtle and Oddish/Paras unless you have Dux
+
+> Option to swap Nidoking and bird pre-fight if you want to save 0-0.5s at the cost of being difficult
+
+Lorelei:
+- Dewgong: Bird Swap, X Acc + HD
+- Cloyster: HD
+- Slowbro: HD
+- Jynx: HD (EQ if PPUP Skip)
+- Lapras: HD
+
+## BRUNO SPLIT
+
+Menu before Bruno:
+- Use an Elixer
+
+Bruno:
+- Onix: X Acc + IB
+- Hitmonchan: HD
+- Hitmonlee: HD
+- Onix: IB
+- Machamp: HD
+
+## AGATHA SPLIT
+
+Menu before Agatha:
+- Super Potion twice to play safe, otherwise heal according to the chart
+- Use Elixer
+
+HP DV | Max HP that keeps redbar after Night Shade | Max HP to yolo
+----- | ------------------------------------------ | --------------
+0-3   | 87                                         | 31
+4-7   | 88                                         | 32
+8-12  | 89                                         | 33
+13-15 | 90                                         | 34
+
+Agatha:
+- Gengar: (X Speed), EQ
+	- Skip X Speed if 13+ SPD (or 11+ and you took 2 Carbos)
+- Golbat: IB x2
+- Haunter: EQ
+- Arbok: EQ
+- Gengar: EQ
+
+## LANCE SPLIT
+
+Menu before Lance:
+- SPC DV | Heal to...
+  ------ | ----------
+  0-3    | 144+
+  4-10   | 134+
+  11-15  | 127+
+
+Lance:
+- Gyarados: X Special + TB
+- 1st Dragonair: IB
+- 2nd Dragonair: X Speed + IB
+- Aerodactyl: IB
+- Dragonite: IB
+
+## CHAMPION SPLIT
+
+Heal to ~26+ before Champ or to ~50+ to play safely (see Red Helper for more specific damage ranges).
+
+Champion:
+- Pidgeot: X Acc + X Speed + HD
+- Alakazam: HD (EQ if skipped PPUP)
+- Rhydon: HD
+- Gyarados: HD
+- Arcanine: HD
+- Venusaur: HD
+
+Things to consider:
+- There are options here with pros and cons to weigh. Play safely on good enough pace.
+WA is 28 damage or 25 damage w/badge boost
+- X Speed first 23-27 is an option; as is Full Restore or Super Potion if Sky Attack turn 1 on good pace
+- Yolo Strat at 1-23 or 28-30 or just in red bar is to X Acc turn 1 and respond to Sky Attack with HD and take the risk using X Speed on Zam (~⅓ to live)

--- a/docs/gen-1/red-blue/main-glitchless/classic-intermediate-route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/classic-intermediate-route/README.md
@@ -31,10 +31,10 @@ Speed DV | Strategy used                         | Alternate strategies         
 </details>
 
 - This guide will always offer Carbos + extra candy strategies to avoid being outsped by Sabrina's Zam (which forces us to set up a very risky X-Speed on Mr. Mime who is 1/3 to use confuision 1/3 to use barrier).
-  - Carbos strategies that are optional have the Speed DVs in () the DVs that have optional carbos pickups are (3-4) and (11-12).
-  - 3 SPD --> 3 Carbos + extra candy in mansion
-  - 4 SPD --> 2 Carbos + extra candy in mansion
-  - 11-12 SPD --> 2 Carbos to outspeed Agath's 1st Gengar this timeloss gives us a less risky Agatha fight (we still heal, but only risk her 2nd Gengar that knows fewer scary moves)
+  - Carbos strategies that are optional have the Speed DVs in ( ) the DVs that have optional carbos pickups are (3-4) and (11-12).
+  - 3 SPD plays safe with 3 Carbos + extra candy in mansion
+  - 4 SPD plays safe with 2 Carbos + extra candy in mansion
+  - 11-12 SPD plays safe with 2 Carbos to outspeed Agath's 1st Gengar this timeloss gives us a less risky Agatha fight (we still heal, but only risk her 2nd Gengar that knows fewer scary moves)
 
 - This guide avoids higher risk red bar strategies by default, but they are available for runs that fall too far behind. Note that Flute-to-End times under 44 minutes are achievable in classic with solid execution and sub 11:00 Fly split is achievable without fly red bar.
 

--- a/docs/gen-1/red-blue/main-glitchless/classic-intermediate-route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/classic-intermediate-route/README.md
@@ -1,7 +1,6 @@
 # Pokemon Red Glitchless Classic Intermediate Guide 
 - This route is a natural next step for runners who have completed a run or two with the beginner route 
 - This route also aims to be the introductory route for runners of red glitchless and runners interested in learning optimal strats right away.
-- For movement and menus watch any recent leaderboard time.
 
 > Note: This route plays safely by default with 3-4 Speed DV by getting the extra 
 

--- a/docs/gen-1/red-blue/main-glitchless/classic-intermediate-route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/classic-intermediate-route/README.md
@@ -2,7 +2,10 @@
 - This route is a natural next step for runners who have completed a run or two with the beginner route 
 - This route also aims to be the introductory route for runners of red glitchless and runners interested in learning optimal strats right away.
 
-> Note: This route plays safely by default with 3-4 Speed DV by getting the extra 
+> Note: This route plays safely by default with 3-4 Speed DV by getting the extra
+>
+> Note for runners moving here from the beginner route:
+> This route has the option to skip TM12 Water Gun with good atk (but you can choose to always get it) and the standard strategy is to skip fighting the gentleman guarding the rare candy on the boat, and we also skip buying revives in favor of buying Super Potions - super potions help us fine tune HP in E4 to consistently get safe red bar for after Lance's Gyarados
 
 - [Resources - Pokémon Red/Blue](https://www.speedrun.com/pkmnredblue/resources)
 	- TOOLS: Download "Red Classic Helper"


### PR DESCRIPTION
Intermediate route = an introductory route for runners already familiar with red from either running glitchless or from completing a few runs with the classic beginner route. Also added some fixes the Advanced Route, boat menu, and added Silph Bar HP strats.