### PR TITLE
Updates to Red Beginner Routes & FAQ

### DIFF
--- a/docs/gen-1/red-blue/main-glitchless/WR-Route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/WR-Route/README.md
@@ -352,15 +352,21 @@ Cycling Road
 - Get the PPUP
 
 Post Cycling Road Menu:
-- Use Super Repel (skip repeling if we only bought 9)
-- Swap slot 4 for TM26
-- Use PPUP on Horn Drill
-- Use slot 4 TM26 teaching EQ over slot 2
 - Bike
 
 Cut the bushes to get to Safari Zone
-- If we bought 9 Super Repels, then Super Repel at the start of safari and yolo two tiles at the end by following [this](https://imgur.com/gallery/JeycmGG) path
-- Otherwise, Super Repel in Zone 3
+
+Menu inside Safari Zone:
+- Use Super Repel 
+- Swap slot 4 for TM26
+- Use PPUP on Horn Drill
+- Bike
+
+> If we bought 9 Super Repels, then teach EQ in the menu above before getting on bike and skip the 2nd Super Repel in Safari. Yolo two tiles at the end by following [this](https://gunnermaniac.com/pokeworld?map=218#39/31/ULLLLLLLLLLLLLLLLLUUUUUUUULLLLLLDDDDDDLLLUUUUUUUUUUUUUUUUUUUUUURRRRRRRRRRRRRRRUUUALLLLUULLLLLLLLLLLLLLLLLLLDDSDDDDDSDDDDDLLDDDDDDDDDDDDDDDDDDDDDD) path.
+
+Menu in Zone 3:
+- Super Repel
+- Teach Slot 4 TM26 to Nido
 
 Dig out after getting Surf then Fly to Fuschia and Bike to the gym
 

--- a/docs/gen-1/red-blue/main-glitchless/WR-Route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/WR-Route/README.md
@@ -351,10 +351,7 @@ Cycling Road
 - Get the Rare Candy
 - Get the PPUP
 
-Post Cycling Road Menu:
-- Bike
-
-Cut the bushes to get to Safari Zone
+Bike to cut the bushes to get to Safari Zone
 
 Menu inside Safari Zone:
 - Use Super Repel 

--- a/docs/gen-1/red-blue/main-glitchless/advanced-route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/advanced-route/README.md
@@ -345,14 +345,17 @@ Snorlax Menu:
 Cycling Road
 - Get the Rare Candy
 
-Post Cycling Road Menu:
+Post Cycling Road:
+- Bike to cut the bushes to get to Safari Zone
+
+**EQ Menu**
 - Use Repel
 - Swap slot 6 for X Special
 - Teach TM26
 - Bike
 
-Cut the bushes to get to Safari Zone
-- Super Repel in Zone 2
+Zone 2
+- Super Repel
 
 Dig out after getting Surf then Fly to Fuschia and Bike to the gym
 

--- a/docs/gen-1/red-blue/main-glitchless/advanced-route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/advanced-route/README.md
@@ -5,6 +5,7 @@ This guide assumes you know things about the game already
 - [Defensive Damage Ranges](../resources/defensive-ranges.md)
 - [Offensive Damage Ranges](../resources/offensive-ranges.md)
 - Keep this document open at all times: [Advanced HP Strats](../resources/hp-strats.md)
+- This guide is still the 2 Max Ether Route, but it will likely be modified soon in favor of getting 1 Ether and 1 Max Ether. Feel free to make the following adjustments to more conistently have an extra blizzard for Agatha: https://pastebin.com/C0mesB6B
 
 ## NIDORAN SPLIT
 

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/lass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/lass/README.md
@@ -686,11 +686,15 @@ Menu after leaving the gym:
 
 ## Victory Road
 
-[Super Repel locations](https://imgur.com/gallery/laeW1PT) and [Victory Road map](https://imgur.com/gallery/vKQYRQZ)
+- After the first badge check, get on the bike.
+
+[Next two Super Repel locations](https://imgur.com/gallery/laeW1PT) and [Victory Road map](https://imgur.com/gallery/vKQYRQZ)
 
 - Pick up the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=34#8/90) from the water
-- Use a Super Repel one step into the cave
-- Watch a top leaderboard run for how to do the Strength boulder puzzles
+- Exit water, super repel, and get on the bike.
+
+> Watch [former world record commentary](https://youtu.be/GR9HKr61HJY?si=bR5OYLIxhdo4q0Ag&t=6576) for Victory Road movement
+
 - Use the 2nd Super Repel on [this tile](https://gunnermaniac.com/pokeworld?map=194#5/14) before using Strength
 - After dropping before the last boulder on [this tile](https://gunnermaniac.com/pokeworld?map=194#24/16):
 	- Use Strength

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/lass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/lass/README.md
@@ -1,7 +1,5 @@
 # Pokemon Red Glitchless Beginner Guide, Lass Version
 
-# Pokemon Red Glitchless Beginner Guide, No-Lass Version
-
 **FAQ: [Please read the FAQ before learning :)](../../resources/faq.md)**
 
 ### Resources
@@ -19,7 +17,6 @@
 	- [Post Hiker Backup Paras](https://pastebin.com/j5gtY4cy) (recommended)
 		- [Easy - Older version](https://pastebin.com/7kcZu3g4) (easier path, but select yoloball)
 	- [Post Nerd Backup Paras](../../resources/postnerd-backup-paras.md)
-	- [Route 3 Moon Manip](https://pastebin.com/tggXpQRC)
 	- [Entr's Moon Manip](https://pastebin.com/jnj9j47S)
 - Surge Cans Manip:
 	- [Optimal](https://www.youtube.com/watch?v=8Pa2f2WxCe4)
@@ -102,7 +99,7 @@ Options: Battle Style to Set before leaving Brock's gym
 - Caterpie: Leer + HA x2 (+ Tackle)
 - Weedle: Leer + HA x2
 	- Leer + HA + Tackle if you got String Shot hit OR Tackle will always kill
-- Caterpie: Leer + HA + Tackle
+- Caterpie: Leer + HA + Tackle or HA x2 + Tackle
 
 Menu:
 - Potion to 28+
@@ -145,7 +142,7 @@ Route 3 grass:
 
 ## Mount Moon
 
-- Do not learn a full Moon Manip for your first runs, start by learning [Post Hiker Backup Paras](https://pastebin.com/j5gtY4cy) (or the easier [older version](https://pastebin.com/7kcZu3g4)) and walk through the first floor normally ([movement map](https://i.imgur.com/xzgmNBk.jpeg)). You will choose later if you want to learn [Entr Moon](https://pastebin.com/jnj9j47S) (works with Lass) or [Route 3 Moon](https://pastebin.com/tggXpQRC) (slightly better, but does not work with Lass strats). There is also a [Post Nerd Backup Paras](../../resources/postnerd-backup-paras.md) you can learn.
+- Do not learn a full Moon Manip for your first runs, start by learning [Post Hiker Backup Paras](https://pastebin.com/j5gtY4cy) (or the easier [older version](https://pastebin.com/7kcZu3g4)) and walk through the first floor normally ([movement map](https://i.imgur.com/xzgmNBk.jpeg)). You will choose later if you want to learn [Entr Moon](https://pastebin.com/jnj9j47S) (works with Lass) or [Route 3 Moon](https://pastebin.com/tggXpQRC) (slightly better, but does not work with Lass strats). There is also a very easy [Post Nerd Backup Paras](../../resources/postnerd-backup-paras.md) you can learn to manip a Paras just before exiting Mt. Moon.
 - Get [TM12 (Water Gun)](https://gunnermaniac.com/pokeworld?map=59#5/32), [Rare Candy](https://gunnermaniac.com/pokeworld?map=59#35/31), [Escape Rope](https://gunnermaniac.com/pokeworld?map=59#36/23), [TM01 (Mega Punch)](https://gunnermaniac.com/pokeworld?map=61#29/5) and [Moon Stone](https://gunnermaniac.com/pokeworld?map=59#2/2)
 - Avoid catching wild Paras as the catch is not guaranteed even at low HP, catch the manipped one instead
 
@@ -480,8 +477,8 @@ Get the Poke Flute and Fly to Celadon City
 
 ## Celadon City
 
-- MUST Take the center in Celadon. Replenishes PP & sets Celadon as the warp point.
-- Bike East to Saffron City, trading Fresh Water for passage, and enter Silph Co.
+- MUST take the center in Celadon. Replenishes PP & sets Celadon as the warp point.
+- Bike East to Saffron City, trading the Fresh Water for passage.
 
 ## Saffron City
 
@@ -691,7 +688,7 @@ Menu after leaving the gym:
 [Next two Super Repel locations](https://imgur.com/gallery/laeW1PT) and [Victory Road map](https://imgur.com/gallery/vKQYRQZ)
 
 - Pick up the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=34#8/90) from the water
-- Exit water, super repel, and get on the bike.
+- Exit water, Super Repel, and get on the bike.
 
 > Watch [former world record commentary](https://youtu.be/GR9HKr61HJY?si=bR5OYLIxhdo4q0Ag&t=6576) for Victory Road movement
 
@@ -767,9 +764,9 @@ After Lance:
 - [OPTIONAL SAVE: Saving for Champ can be good if you don't have a spare X Accuracy + X Special + Revive]
 
 **Champion:**
-Pidgeot: **Turn 1: USE X SPECIAL**, then adapt:
-	- If Pidgeot does NOT use Sky Attack on turn 1:
-		- Pidgeot: use X Acc on turn 2, HD
+- Pidgeot: X Spec
+	- If Pidgeot does NOT use Sky Attack turn 1:
+		- Pidgeot: X Acc + HD
 		- Alakazam: HD
 		- Rhydon: HD
 		- Gyarados: **TB**

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/lass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/lass/README.md
@@ -1,15 +1,25 @@
 # Pokemon Red Glitchless Beginner Guide, Lass Version
 
+# Pokemon Red Glitchless Beginner Guide, No-Lass Version
+
 **FAQ: [Please read the FAQ before learning :)](../../resources/faq.md)**
+
+### Resources
+- [How To Speedrun Pokemon on Emulator](https://youtu.be/nf51DyXg-OY)
+- Watch the [RBY Manip Guide](https://youtu.be/QirPrbub21g?si=ec8acTpec_vi7moy)
+- [Resources - Pokémon Red/Blue](https://www.speedrun.com/pkmnredblue/resources)
+	- SAVES: Download "Any% Glitchless (Beginner Route)"
+ 	- RBY Savestate Patcher can be used to make your own practice ROM
 
 ### Manip quick reference
 - Nidoran Manip:
 	- [Optimal](../../resources/nido-manip.md) (HIGHLY RECOMMENDED)
-	- [1 A Press](https://youtu.be/2bwQZ6jPxRE)
+	- [Easy - 1 A Press](https://youtu.be/2bwQZ6jPxRE)
 - Mount Moon Manip:
-	- [Post Hiker Backup Paras](https://pastebin.com/j5gtY4cy) (recommended for first runs)
-		- [Older version](https://pastebin.com/7kcZu3g4) (easier path, but select yoloball)
+	- [Post Hiker Backup Paras](https://pastebin.com/j5gtY4cy) (recommended)
+		- [Easy - Older version](https://pastebin.com/7kcZu3g4) (easier path, but select yoloball)
 	- [Post Nerd Backup Paras](../../resources/postnerd-backup-paras.md)
+	- [Route 3 Moon Manip](https://pastebin.com/tggXpQRC)
 	- [Entr's Moon Manip](https://pastebin.com/jnj9j47S)
 - Surge Cans Manip:
 	- [Optimal](https://www.youtube.com/watch?v=8Pa2f2WxCe4)
@@ -20,6 +30,7 @@
 - [Defensive Damage Ranges](../../resources/defensive-ranges.md)
 - [Offensive Damage Ranges](../../resources/offensive-ranges.md)
 - [Safety-oriented HP Strats](../../resources/hp-strats-for-races.md)
+
 
 ### Glossary
 - Moves: HA = Horn Attack, MP = Mega Punch, BB = Bubblebeam, WG = Water Gun, TB = Thunderbolt, Blizz = Blizzard, PS = Poison Sting, HD = Horn Drill, RS = Rock Slide
@@ -48,7 +59,7 @@ Shopping:
 
 Nidoran Manip:
 - [Optimal (HIGHLY RECOMMENDED)](../../resources/nido-manip.md)
-- [1 A Press](https://youtu.be/qPzSWHyMuW8)
+- [Easy - 1 A Press](https://youtu.be/qPzSWHyMuW8)
 
 Get the [hidden Tree Potion](https://gunnermaniac.com/pokeworld?map=1#54/166)
 
@@ -91,11 +102,13 @@ Options: Battle Style to Set before leaving Brock's gym
 - Caterpie: Leer + HA x2 (+ Tackle)
 - Weedle: Leer + HA x2
 	- Leer + HA + Tackle if you got String Shot hit OR Tackle will always kill
-- Caterpie: HA x2 + Tackle
+- Caterpie: Leer + HA + Tackle
 
 Menu:
 - Potion to 28+
 - Toss Antidote if you still have it
+
+<img src="https://i.imgur.com/recEFU5.png" height=125>
 
 **Shorts Guy:**
 - Rat: [1-15 Potion]
@@ -132,7 +145,7 @@ Route 3 grass:
 
 ## Mount Moon
 
-- Do not learn a full Moon Manip for your first runs, start by learning [Post Hiker Backup Paras](https://pastebin.com/j5gtY4cy) (or the [older version](https://pastebin.com/7kcZu3g4)) and walk through the first floor normally ([movement map](https://i.imgur.com/xzgmNBk.jpeg)). You will choose later if you want to learn [Entr Moon](https://pastebin.com/jnj9j47S) (works with Lass) or [Route 3 Moon](https://pastebin.com/tggXpQRC) (slightly better, but does not work with Lass strats). There is also a [Post Nerd Backup Paras](../../resources/postnerd-backup-paras.md) you can learn.
+- Do not learn a full Moon Manip for your first runs, start by learning [Post Hiker Backup Paras](https://pastebin.com/j5gtY4cy) (or the easier [older version](https://pastebin.com/7kcZu3g4)) and walk through the first floor normally ([movement map](https://i.imgur.com/xzgmNBk.jpeg)). You will choose later if you want to learn [Entr Moon](https://pastebin.com/jnj9j47S) (works with Lass) or [Route 3 Moon](https://pastebin.com/tggXpQRC) (slightly better, but does not work with Lass strats). There is also a [Post Nerd Backup Paras](../../resources/postnerd-backup-paras.md) you can learn.
 - Get [TM12 (Water Gun)](https://gunnermaniac.com/pokeworld?map=59#5/32), [Rare Candy](https://gunnermaniac.com/pokeworld?map=59#35/31), [Escape Rope](https://gunnermaniac.com/pokeworld?map=59#36/23), [TM01 (Mega Punch)](https://gunnermaniac.com/pokeworld?map=61#29/5) and [Moon Stone](https://gunnermaniac.com/pokeworld?map=59#2/2)
 - Avoid catching wild Paras as the catch is not guaranteed even at low HP, catch the manipped one instead
 
@@ -199,6 +212,8 @@ If you still need Paras: [Post Nerd Backup Paras](../../resources/postnerd-backu
 - Zubat: HA
 
 ## Route 25
+
+<img src="https://i.imgur.com/DwLHG3g.png" height=125>
 
 **Bottom Hiker:**
 - WG
@@ -276,6 +291,8 @@ Depending of your HP, you may fight the Gentleman in [this room](https://gunnerm
 | 2-8   | Do Gentleman                            |
 | 9-24  | Do Gentleman if you want to play safely |
 
+> Important note for shopping right now in Vermillion and later in Celadon: **always buy items in the order that they are listed in this guide**. Doing so is both the fastest way to buy the items and sets up our inventory in the correct order.
+
 Shopping:
 - Buy:
 	- 6 Repels
@@ -302,7 +319,7 @@ Surge Cans Manip:
 - Raichu:
 	- If you are confused and dead to a self hit, swap to your bird or Squirtle
 
-Get the Bike Voucher and use Dig on Paras
+Go to the [fan club](https://gunnermaniac.com/pokeworld?map=1#229/194), get the Bike Voucher, and immediately menu to use Dig.
 
 ## Cerulean City
 
@@ -310,7 +327,7 @@ Get the Bike Voucher and use Dig on Paras
 - Menu:
 	- Swap (using select) slot 1 with the Bike
 	- Teach TM24 (Thunderbolt) over HA (slot 3)
-	- Use the Bike
+	- Use the Bike, cut both trees to head east into Route 9
 
 ## Route 9
 
@@ -319,16 +336,18 @@ Get the Bike Voucher and use Dig on Paras
 - Thrash
 	- If you run out of MP just Thrash, you will be 25% to hit yourself on the last poke
 
-**Bug Catcher:**
+[**Bug Catcher:**](https://gunnermaniac.com/pokeworld?map=1#300/52)
 - BB (Thrash if you fought the Gentleman)
 - Thrash
 
 ## Rock Tunnel
 
-[Map of both floors](https://imgur.com/gallery/uoueIjq)
-
 Menu after taking 1 step down:
 - Scroll down and use a Repel
+
+| Tunnel 1F                                   | Tunnel B1F                                  |
+| ------------------------------------------- | ------------------------------------------- |
+| <img src="https://i.imgur.com/LllktGo.png"> | <img src="https://i.imgur.com/cS4hPoI.png"> |
 
 **Pokemaniac 1:**
 - BB
@@ -341,14 +360,14 @@ Menu after taking 1 step down:
 
 **Oddish Girl:**
 - If you fought the Gentleman, Thrash. The ranges are guaranteed
-- 18-22 TB, then Thrash
+- 18-22 TB + Thrash
 - Otherwise, just Thrash
 	- If you get put to sleep, Potion at 1-5
 	- If paralyzed, keep using Thrash
 
 After the fight:
-- Use one Repel [here](https://gunnermaniac.com/pokeworld?map=232#25/19)
-- Use another Repel [here](https://gunnermaniac.com/pokeworld?map=232#8/17)
+- Use one Repel around [here](https://gunnermaniac.com/pokeworld?map=232#25/19/S)
+- Use another Repel around [here](https://gunnermaniac.com/pokeworld?map=232#8/17/S)
 	- If you were paralyzed, use a Parlyz Heal now
 	- You can delay these 2 Repels up to ~10 tiles
 
@@ -358,9 +377,15 @@ After the fight:
 **Jr Trainer F:**
 - Thrash
 
-Get the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=21#16/53)
+<img src="https://i.imgur.com/0WpaVOx.png">
+
+Get the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=21#16/53) and bike straight down into Lavender to avoid the optional trainer.
 
 ## Route 8
+
+Bike west and fight the Gambler.
+
+<img src="https://i.imgur.com/1EHC3r4.png">
 
 **Gambler:**
 - Growlithe:
@@ -370,8 +395,13 @@ Get the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=21#16/53)
 
 ## Underground
 
-- Get the [hidden Elixer](http://gunnermaniac.com/pokeworld?map=121#21/5)
-- Get the [hidden Nugget](http://gunnermaniac.com/pokeworld?map=121#12/2)
+Be careful not to hit optionals. Take the underground path to Celadon City.
+
+<img src="https://i.imgur.com/3TbEDS8.png">
+
+Pick up the [hidden Elixer](http://gunnermaniac.com/pokeworld?map=121#21/5) and the [hidden Nugget](http://gunnermaniac.com/pokeworld?map=121#12/2) marked below:
+
+<img src="https://i.imgur.com/Jh9E0Cd.jpeg">
 
 ## Celadon City
 
@@ -393,19 +423,19 @@ Shopping:
 	- Buy 9 X Specs (7 if you have 0 Potions at this point)
 	- Buy 1 X Speeds (3 if you have 0 Potions at this point)
 
-Take the elevator and get HM02 (Fly)
+Take the elevator out and bike West to get HM02 (Fly)
 
-Menu after getting Fly:
+Exit the Fly House and Menu:
 - Swap slot 2 with TM07
 - Use a Super Repel
 - Teach TM48 (Rock Slide) over Mega Punch (slot 1)
 - Swap slot 3 with X Accs
 - Teach HM02 to the bird
-- Use Fly to go to Lavender
+- Use Fly to go to Lavender (toggle down 3)
 
 ## Lavender Town
 
-Note: From this point on you have 2 Revives which means deaths aren't as scary, so if you die remember to swap to a pokemon, Revive, let the swapped pokemon die and ANY AND ALL X ITEMS ARE GONE. This route has extras so you shouldn't run out of X items, and there will still be some saving since some deaths with Revives are still really slow to come back from if at all.
+> Note: From this point on you have 2 Revives which means deaths aren't as scary. If you die remember to swap to another pokemon, Revive Nido, let the swapped pokemon get KO'd and know that ANY AND ALL X ITEMS USED ARE NO LONGER ACTIVE. This route has plenty of extras so you shouldn't run out of X items. There will still be some saving since some deaths with Revives are still really slow to come back from if at all.
 
 **Rival:**
 - Pidgeotto:
@@ -450,18 +480,22 @@ Get the Poke Flute and Fly to Celadon City
 
 ## Celadon City
 
-- Use the center
-- Bike to Saffron City
+- MUST Take the center in Celadon. Replenishes PP & sets Celadon as the warp point.
+- Bike East to Saffron City, trading Fresh Water for passage, and enter Silph Co.
 
 ## Saffron City
 
-- Enter Silph Co and take the stairs to floor 5
-- Get the [hidden Elixer](http://gunnermaniac.com/pokeworld?map=210#12/3)
+<img align="right" src="https://i.imgur.com/WAid12E.jpeg" height=200>
 
-**Rocket 1:**
-- Thrash
+- Enter Silph Co and take the stairs to floor 5
+- Walk left and get the [hidden Elixer](http://gunnermaniac.com/pokeworld?map=210#12/3) in the plant, then walk down and talk to the Rocket next to the teleport pad.
+
+**Rocket 1: Silph Arbok**
+- Thrash x2-3
 
 Get the Card Key
+
+<img align="right" src="https://i.imgur.com/MEpyFTQ.png" height=175>
 
 **Rival:**
 - Pidgeot:
@@ -470,7 +504,7 @@ Get the Card Key
 	- X Speed
 - HD x5
 
-Note: In this split we want to take a bit of damage to do a strat on Koga called Boom Strats
+> Note: In this split we want to take a bit of damage to do a strat on Koga called Boom Strats. We intentionally allow Koga's Weezing to KO Nido and we use our rare candies after exiting Koga's gym. The end result is that Nido holds safe red bar through the last 4 gym leaders and first two E4 members for several minutes of timesave.
 
 If 1-77, use an Elixer before the next fight
 
@@ -508,20 +542,27 @@ Menu before Snorlax:
 - Note: You can hold B to stop automatically moving down on Cycling Road
 - Get the [hidden Rare Candy](http://gunnermaniac.com/pokeworld?map=1#125/148)
 
+<img src="https://i.imgur.com/klM3YDH.jpeg" height=350>
+
 ## Fuschia City
 
-Menu:
+Get back on the bike and cut both trees to enter the Safari Zone
+
+[Safari Movement Map](https://imgur.com/gallery/h9KpU3I)
+
+Menu after entering Safari Zone:
 - Use a Repel
 - Swap slot 6 (Potion) with X Spec (if 0 Potions, then swap Helix Fossil with X Spec instead)
 - Teach TM26 (Earthquake) over Thrash (slot 2)
 - Use Bike
 
-[Safari Movement Map](https://imgur.com/gallery/h9KpU3I)
+In Zone 2:
+- Super Repel on the 2nd map around [this tile](https://gunnermaniac.com/pokeworld?map=217#20/24/S)
+- Pick up the [Teeth](https://gunnermaniac.com/pokeworld?map=219#19/7) and enter the house to get HM03 Surf
+- Exit the house and menu to use Dig out of the safari and Fly back to Fuschia City (toggle down 2)
+- Walk West into Koga's gym.
 
-In the Safari Zone:
-- Super Repel on the 2nd map around [this tile](https://gunnermaniac.com/pokeworld?map=217#13/24)
-- Pick up the [Teeth](https://gunnermaniac.com/pokeworld?map=219#19/7) and get Surf
-- After getting Surf, Dig out of the safari and Fly back to Fuschia City
+<img align="right" src="https://i.imgur.com/NmNe7CB.png" height=175>
 
 **Juggler 1:**
 - EQ x4
@@ -539,7 +580,8 @@ In the Safari Zone:
 
 Menu after Koga:
 - Use all Rare Candies
-- Bike to get Strength
+- Bike East (hopping the ledge) to the Warden's house
+- Get HM04 Strength
 - Fly to Pallet Town
 
 ## Pallet Town
@@ -549,7 +591,19 @@ Menu at the bottom of the water:
 - Teach HM03 (Surf) to Squirtle
 - Surf
 
+> Go straight down, just side step one tile left to not bonk fisherman
+
 ## Cinnabar Island
+
+Inside Mansion:
+- Take the stairs up
+- Walk up around/above to the next stairs.
+
+<img align="right" src="https://i.imgur.com/VQu8itp.png" height=350>
+
+Hit the switch and fall through the hole:
+
+Avoid the scientist, skip the item ball, and take the stairs.
 
 - Pick up TM14 (Blizzard)
 - Menu:
@@ -562,7 +616,7 @@ Menu at the bottom of the water:
 
 ## Celadon City
 
-Bike to the gym
+Bike to [Erika's Gym](https://gunnermaniac.com/pokeworld?map=1#162/136) and follow [this path](https://i.imgur.com/fWP9bAh.png) inside the gym.
 
 **Beauty:**
 - Blizz
@@ -572,7 +626,7 @@ Bike to the gym
 - Blizz
 - EQ
 
-Fly back to Cinnabar
+Exit the gym and fly back to Cinnabar (toggle down 2)
 
 ## Cinnabar Island
 
@@ -582,7 +636,7 @@ Quiz answers: A B B B A B
 - X Acc + EQ
 - HD x3
 
-Dig out and Bike to Sabrina's gym
+Dig out and Bike East to [Sabrina’s gym](https://gunnermaniac.com/pokeworld?map=1#254/112/S) by walking through the guard house.
 
 ## Saffron City
 
@@ -591,9 +645,11 @@ Teleporter puzzle: Top left, Bottom left, Bottom left
 **Sabrina:**
 - EQ x4
 
-Walk back to the teleporter and Dig out and Fly to
+Walk back to the teleporter and Dig out and Fly to Viridian (toggle up 1)
 
 ## Viridian City
+
+Bike to Giovanni's Gym and follow [this path](https://i.imgur.com/vWBah5K.png) inside the gym to save before the Blackbelt.
 
 **Cooltrainer:**
 - EQ
@@ -638,8 +694,8 @@ Menu after leaving the gym:
 - Use the 2nd Super Repel on [this tile](https://gunnermaniac.com/pokeworld?map=194#5/14) before using Strength
 - After dropping before the last boulder on [this tile](https://gunnermaniac.com/pokeworld?map=194#24/16):
 	- Use Strength
-	- Use a Max Ether on HD
-	- Super Repel
+	- Down to use a Max Ether on HD
+	- Up to use last Super Repel
 	- Bike
 - Optional Safety: Pick up the [Full Restore](http://gunnermaniac.com/pokeworld?map=194#26/7)
 
@@ -707,9 +763,9 @@ After Lance:
 - [OPTIONAL SAVE: Saving for Champ can be good if you don't have a spare X Accuracy + X Special + Revive]
 
 **Champion:**
-- Pidgeot: X Spec
-	- If Pidgeot does NOT use Sky Attack turn 1:
-		- Pidgeot: X Acc + HD
+Pidgeot: **Turn 1: USE X SPECIAL**, then adapt:
+	- If Pidgeot does NOT use Sky Attack on turn 1:
+		- Pidgeot: use X Acc on turn 2, HD
 		- Alakazam: HD
 		- Rhydon: HD
 		- Gyarados: **TB**

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/nolass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/nolass/README.md
@@ -701,11 +701,15 @@ Menu after leaving the gym:
 
 ## Victory Road
 
-[Super Repel locations](https://imgur.com/gallery/laeW1PT) and [Victory Road map](https://imgur.com/gallery/vKQYRQZ)
+- After the first badge check, get on the bike.
+
+[Next two Super Repel locations](https://imgur.com/gallery/laeW1PT) and [Victory Road map](https://imgur.com/gallery/vKQYRQZ)
 
 - Pick up the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=34#8/90) from the water
-- Use a Super Repel one step into the cave
-- Watch a top leaderboard run for how to do the Strength boulder puzzles
+- Exit water, super repel, and get on the bike.
+
+> Watch [former world record commentary](https://youtu.be/GR9HKr61HJY?si=bR5OYLIxhdo4q0Ag&t=6576) for Victory Road movement
+
 - Use the 2nd Super Repel on [this tile](https://gunnermaniac.com/pokeworld?map=194#5/14) before using Strength
 - After dropping before the last boulder on [this tile](https://gunnermaniac.com/pokeworld?map=194#24/16):
 	- Use Strength

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/nolass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/nolass/README.md
@@ -557,22 +557,27 @@ Menu before Snorlax:
 - Note: You can hold B to stop automatically moving down on Cycling Road
 - Get the [hidden Rare Candy](http://gunnermaniac.com/pokeworld?map=1#125/148)
 
-<img src="https://i.imgur.com/klM3YDH.jpeg">
+<img src="https://i.imgur.com/klM3YDH.jpeg" height=350>
 
 ## Fuschia City
 
-Menu:
+Get back on the bike and cut both trees to enter the Safari Zone
+
+[Safari Movement Map](https://imgur.com/gallery/h9KpU3I)
+
+Menu after entering Safari Zone:
 - Use a Repel
 - Swap slot 6 (Potion) with X Spec (if 0 Potions, then swap Helix Fossil with X Spec instead)
 - Teach TM26 (Earthquake) over Thrash (slot 2)
 - Use Bike
 
-[Safari Movement Map](https://imgur.com/gallery/h9KpU3I)
+In Zone 2:
+- Super Repel on the 2nd map around [this tile](https://gunnermaniac.com/pokeworld?map=217#20/24/S)
+- Pick up the [Teeth](https://gunnermaniac.com/pokeworld?map=219#19/7) and enter the house to get HM03 Surf
+- Exit the house and menu to use Dig out of the safari and Fly back to Fuschia City (toggle down 2)
+- Walk West into Koga's gym.
 
-In the Safari Zone:
-- Super Repel on the 2nd map around [this tile](https://gunnermaniac.com/pokeworld?map=217#13/24)
-- Pick up the [Teeth](https://gunnermaniac.com/pokeworld?map=219#19/7) and get Surf
-- After getting Surf, Dig out of the safari and Fly back to Fuschia City
+<img align="right" src="https://i.imgur.com/NmNe7CB.png" height=175>
 
 **Juggler 1:**
 - EQ x4
@@ -590,7 +595,8 @@ In the Safari Zone:
 
 Menu after Koga:
 - Use all Rare Candies
-- Bike to get Strength
+- Bike East (hopping the ledge) to the Warden's house
+- Get HM04 Strength
 - Fly to Pallet Town
 
 ## Pallet Town
@@ -600,7 +606,19 @@ Menu at the bottom of the water:
 - Teach HM03 (Surf) to Squirtle
 - Surf
 
+> Go straight down, just side step one tile left to not bonk fisherman
+
 ## Cinnabar Island
+
+Inside Mansion:
+- Take the stairs up
+- Walk up around/above to the next stairs.
+
+<img align="right" src="https://i.imgur.com/VQu8itp.png" height=350>
+
+Hit the switch and fall through the hole:
+
+Avoid the scientist, skip the item ball, and take the stairs.
 
 - Pick up TM14 (Blizzard)
 - Menu:

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/nolass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/nolass/README.md
@@ -782,9 +782,9 @@ After Lance:
 - [OPTIONAL SAVE: Saving for Champ can be good if you don't have a spare X Accuracy + X Special + Revive]
 
 **Champion:**
-Pidgeot: **Turn 1: USE X SPECIAL**, then adapt:
-	- If Pidgeot does NOT use Sky Attack on turn 1:
-		- Pidgeot: use X Acc on turn 2, HD
+- Pidgeot: X Spec
+	- If Pidgeot does NOT use Sky Attack turn 1:
+		- Pidgeot: X Acc + HD
 		- Alakazam: HD
 		- Rhydon: HD
 		- Gyarados: **TB**

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/nolass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/nolass/README.md
@@ -631,7 +631,7 @@ Avoid the scientist, skip the item ball, and take the stairs.
 
 ## Celadon City
 
-Bike to the gym
+Bike to [Erika's Gym](https://gunnermaniac.com/pokeworld?map=1#162/136) and follow [this path](https://i.imgur.com/fWP9bAh.png) inside the gym.
 
 **Beauty:**
 - Blizz
@@ -641,7 +641,7 @@ Bike to the gym
 - Blizz
 - EQ
 
-Fly back to Cinnabar
+Exit the gym and fly back to Cinnabar (toggle down 2)
 
 ## Cinnabar Island
 
@@ -651,7 +651,7 @@ Quiz answers: A B B B A B
 - X Acc + EQ
 - HD x3
 
-Dig out and Bike to Sabrina's gym
+Dig out and Bike East to [Sabrina’s gym](https://gunnermaniac.com/pokeworld?map=1#254/112/S) by walking through the guard house.
 
 ## Saffron City
 
@@ -660,9 +660,11 @@ Teleporter puzzle: Top left, Bottom left, Bottom left
 **Sabrina:**
 - EQ x4
 
-Walk back to the teleporter and Dig out and Fly to
+Walk back to the teleporter and Dig out and Fly to Viridian (toggle up 1)
 
 ## Viridian City
+
+Bike to Giovanni's Gym and follow [this path](https://i.imgur.com/vWBah5K.png) inside the gym to save before the Blackbelt.
 
 **Cooltrainer:**
 - EQ
@@ -707,8 +709,8 @@ Menu after leaving the gym:
 - Use the 2nd Super Repel on [this tile](https://gunnermaniac.com/pokeworld?map=194#5/14) before using Strength
 - After dropping before the last boulder on [this tile](https://gunnermaniac.com/pokeworld?map=194#24/16):
 	- Use Strength
-	- Use a Max Ether on HD
-	- Super Repel
+	- Down to use a Max Ether on HD
+	- Up to use last Super Repel
 	- Bike
 - Optional Safety: Pick up the [Full Restore](http://gunnermaniac.com/pokeworld?map=194#26/7)
 
@@ -776,9 +778,9 @@ After Lance:
 - [OPTIONAL SAVE: Saving for Champ can be good if you don't have a spare X Accuracy + X Special + Revive]
 
 **Champion:**
-- Pidgeot: X Spec
-	- If Pidgeot does NOT use Sky Attack turn 1:
-		- Pidgeot: X Acc + HD
+Pidgeot: **Turn 1: USE X SPECIAL**, then adapt:
+	- If Pidgeot does NOT use Sky Attack on turn 1:
+		- Pidgeot: use X Acc on turn 2, HD
 		- Alakazam: HD
 		- Rhydon: HD
 		- Gyarados: **TB**

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/nolass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/nolass/README.md
@@ -706,7 +706,7 @@ Menu after leaving the gym:
 [Next two Super Repel locations](https://imgur.com/gallery/laeW1PT) and [Victory Road map](https://imgur.com/gallery/vKQYRQZ)
 
 - Pick up the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=34#8/90) from the water
-- Exit water, super repel, and get on the bike.
+- Exit water, Super Repel, and get on the bike.
 
 > Watch [former world record commentary](https://youtu.be/GR9HKr61HJY?si=bR5OYLIxhdo4q0Ag&t=6576) for Victory Road movement
 

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/nolass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/nolass/README.md
@@ -2,13 +2,20 @@
 
 **FAQ: [Please read the FAQ before learning :)](../../resources/faq.md)**
 
+### Resources
+- [How To Speedrun Pokemon on Emulator](https://youtu.be/nf51DyXg-OY)
+- Watch the [RBY Manip Guide](https://youtu.be/QirPrbub21g?si=ec8acTpec_vi7moy)
+- [Resources - Pokémon Red/Blue](https://www.speedrun.com/pkmnredblue/resources)
+	- SAVES: Download "Any% Glitchless (Beginner Route)"
+ 	- RBY Savestate Patcher can be used to make your own practice ROM
+
 ### Manip quick reference
 - Nidoran Manip:
 	- [Optimal](../../resources/nido-manip.md) (HIGHLY RECOMMENDED)
-	- [1 A Press](https://youtu.be/2bwQZ6jPxRE)
+	- [Easy - 1 A Press](https://youtu.be/2bwQZ6jPxRE)
 - Mount Moon Manip:
-	- [Post Hiker Backup Paras](https://pastebin.com/j5gtY4cy) (recommended for first runs)
-		- [Older version](https://pastebin.com/7kcZu3g4) (easier path, but select yoloball)
+	- [Post Hiker Backup Paras](https://pastebin.com/j5gtY4cy) (recommended)
+		- [Easy - Older version](https://pastebin.com/7kcZu3g4) (easier path, but select yoloball)
 	- [Post Nerd Backup Paras](../../resources/postnerd-backup-paras.md)
 	- [Route 3 Moon Manip](https://pastebin.com/tggXpQRC)
 	- [Entr's Moon Manip](https://pastebin.com/jnj9j47S)
@@ -21,6 +28,7 @@
 - [Defensive Damage Ranges](../../resources/defensive-ranges.md)
 - [Offensive Damage Ranges](../../resources/offensive-ranges.md)
 - [Safety-oriented HP Strats](../../resources/hp-strats-for-races.md)
+
 
 ### Glossary
 - Moves: HA = Horn Attack, MP = Mega Punch, BB = Bubblebeam, WG = Water Gun, TB = Thunderbolt, Blizz = Blizzard, PS = Poison Sting, HD = Horn Drill, RS = Rock Slide
@@ -49,7 +57,7 @@ Shopping:
 
 Nidoran Manip:
 - [Optimal (HIGHLY RECOMMENDED)](../../resources/nido-manip.md)
-- [1 A Press](https://youtu.be/qPzSWHyMuW8)
+- [Easy - 1 A Press](https://youtu.be/qPzSWHyMuW8)
 
 Get the [hidden Tree Potion](https://gunnermaniac.com/pokeworld?map=1#54/166)
 
@@ -98,6 +106,8 @@ Menu:
 - Potion to 28+
 - Toss Antidote if you still have it
 
+<img src="https://i.imgur.com/recEFU5.png" height=125>
+
 **Shorts Guy:**
 - Rat: [1-15 Potion]
 	- Leer + HA x2
@@ -129,7 +139,7 @@ Catch a flyer:
 
 ## Mount Moon
 
-- Do not learn a full Moon Manip for your first runs, start by learning [Post Hiker Backup Paras](https://pastebin.com/j5gtY4cy) (or the [older version](https://pastebin.com/7kcZu3g4)) and walk through the first floor normally ([movement map](https://i.imgur.com/xzgmNBk.jpeg)). You will choose later if you want to learn [Route 3 Moon](https://pastebin.com/tggXpQRC) (optimal for this route) or [Entr Moon](https://pastebin.com/jnj9j47S) (slightly less optimal, but still perfectly fine). There is also a [Post Nerd Backup Paras](../../resources/postnerd-backup-paras.md) you can learn.
+- Do not learn a full Moon Manip for your first runs, start by learning [Post Hiker Backup Paras](https://pastebin.com/j5gtY4cy) (or the easier [older version](https://pastebin.com/7kcZu3g4)) and walk through the first floor normally ([movement map](https://i.imgur.com/xzgmNBk.jpeg)). You will choose later if you want to learn [Route 3 Moon](https://pastebin.com/tggXpQRC) (optimal for this route) or [Entr Moon](https://pastebin.com/jnj9j47S) (slightly less optimal, but still perfectly fine). There is also a very easy [Post Nerd Backup Paras](../../resources/postnerd-backup-paras.md) you can learn to manip a Paras just before exiting Mt. Moon.
 - Get [TM12 (Water Gun)](https://gunnermaniac.com/pokeworld?map=59#5/32), [Rare Candy](https://gunnermaniac.com/pokeworld?map=59#35/31), [Escape Rope](https://gunnermaniac.com/pokeworld?map=59#36/23), [TM01 (Mega Punch)](https://gunnermaniac.com/pokeworld?map=61#29/5) and [Moon Stone](https://gunnermaniac.com/pokeworld?map=59#2/2)
 - Avoid catching wild Paras as the catch is not guaranteed even at low HP, catch the manipped one instead
 
@@ -217,6 +227,8 @@ If you still need Paras: [Post Nerd Backup Paras](../../resources/postnerd-backu
 
 ## Route 25
 
+<img src="https://i.imgur.com/DwLHG3g.png" height=125>
+
 **Bottom Hiker:**
 - WG
 
@@ -294,6 +306,8 @@ Depending of your HP, you may fight the Gentleman in [this room](https://gunnerm
 | 2-8   | Do Gentleman                            |
 | 9-24  | Do Gentleman if you want to play safely |
 
+> Important note for shopping right now in Vermillion and later in Celadon: **always buy items in the order that they are listed in this guide**. Doing so is both the fastest way to buy the items and sets up our inventory in the correct order.
+
 Shopping:
 - Buy:
 	- 6 Repels
@@ -320,7 +334,7 @@ Surge Cans Manip:
 - Raichu:
 	- If you are confused and dead to a self hit, swap to your bird or Squirtle
 
-Get the Bike Voucher and use Dig on Paras
+Go to the [fan club](https://gunnermaniac.com/pokeworld?map=1#229/194), get the Bike Voucher, and immediately menu to use Dig.
 
 ## Cerulean City
 
@@ -328,7 +342,7 @@ Get the Bike Voucher and use Dig on Paras
 - Menu:
 	- Swap (using select) slot 1 with the Bike
 	- Teach TM24 (Thunderbolt) over HA (slot 3)
-	- Use the Bike
+	- Use the Bike, cut both trees to head east into Route 9
 
 ## Route 9
 
@@ -337,16 +351,18 @@ Get the Bike Voucher and use Dig on Paras
 - Thrash
 	- If you run out of MP just Thrash, you will be 25% to hit yourself on the last poke
 
-**Bug Catcher:**
+[**Bug Catcher:**](https://gunnermaniac.com/pokeworld?map=1#300/52)
 - BB (Thrash if you fought the Gentleman)
 - Thrash
 
 ## Rock Tunnel
 
-[Map of both floors](https://imgur.com/gallery/uoueIjq)
-
 Menu after taking 1 step down:
 - Scroll down and use a Repel
+
+| Tunnel 1F                                   | Tunnel B1F                                  |
+| ------------------------------------------- | ------------------------------------------- |
+| <img src="https://i.imgur.com/LllktGo.png"> | <img src="https://i.imgur.com/cS4hPoI.png"> |
 
 **Pokemaniac 1:**
 - BB
@@ -365,8 +381,8 @@ Menu after taking 1 step down:
 	- If paralyzed, keep using Thrash
 
 After the fight:
-- Use one Repel [here](https://gunnermaniac.com/pokeworld?map=232#25/19)
-- Use another Repel [here](https://gunnermaniac.com/pokeworld?map=232#8/17)
+- Use one Repel around [here](https://gunnermaniac.com/pokeworld?map=232#25/19/S)
+- Use another Repel around [here](https://gunnermaniac.com/pokeworld?map=232#8/17/S)
 	- If you were paralyzed, use a Parlyz Heal now
 	- You can delay these 2 Repels up to ~10 tiles
 
@@ -376,9 +392,15 @@ After the fight:
 **Jr Trainer F:**
 - Thrash
 
-Get the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=21#16/53)
+<img src="https://i.imgur.com/0WpaVOx.png">
+
+Get the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=21#16/53) and bike straight down into Lavender to avoid the optional trainer.
 
 ## Route 8
+
+Bike west and fight the Gambler.
+
+<img src="https://i.imgur.com/1EHC3r4.png">
 
 **Gambler:**
 - Growlithe:
@@ -388,8 +410,13 @@ Get the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=21#16/53)
 
 ## Underground
 
-- Get the [hidden Elixer](http://gunnermaniac.com/pokeworld?map=121#21/5)
-- Get the [hidden Nugget](http://gunnermaniac.com/pokeworld?map=121#12/2)
+Be careful not to hit optionals. Take the underground path to Celadon City.
+
+<img src="https://i.imgur.com/3TbEDS8.png">
+
+Pick up the [hidden Elixer](http://gunnermaniac.com/pokeworld?map=121#21/5) and the [hidden Nugget](http://gunnermaniac.com/pokeworld?map=121#12/2) marked below:
+
+<img src="https://i.imgur.com/Jh9E0Cd.jpeg">
 
 ## Celadon City
 
@@ -411,19 +438,19 @@ Shopping:
 	- Buy 9 X Specs (7 if you have 0 Potions at this point)
 	- Buy 1 X Speeds (3 if you have 0 Potions at this point)
 
-Take the elevator and get HM02 (Fly)
+Take the elevator out and bike West to get HM02 (Fly)
 
-Menu after getting Fly:
+Exit the Fly House and Menu:
 - Swap slot 2 with TM07
 - Use a Super Repel
 - Teach TM48 (Rock Slide) over Mega Punch (slot 1)
 - Swap slot 3 with X Accs
 - Teach HM02 to the bird
-- Use Fly to go to Lavender
+- Use Fly to go to Lavender (toggle down 3)
 
 ## Lavender Town
 
-Note: From this point on you have 2 Revives which means deaths aren't as scary, so if you die remember to swap to a pokemon, Revive, let the swapped pokemon die and ANY AND ALL X ITEMS ARE GONE. This route has extras so you shouldn't run out of X items, and there will still be some saving since some deaths with Revives are still really slow to come back from if at all.
+> Note: From this point on you have 2 Revives which means deaths aren't as scary. If you die remember to swap to another pokemon, Revive Nido, let the swapped pokemon get KO'd and know that ANY AND ALL X ITEMS USED ARE NO LONGER ACTIVE. This route has plenty of extras so you shouldn't run out of X items. There will still be some saving since some deaths with Revives are still really slow to come back from if at all.
 
 **Rival:**
 - Pidgeotto:
@@ -468,18 +495,22 @@ Get the Poke Flute and Fly to Celadon City
 
 ## Celadon City
 
-- Use the center
-- Bike to Saffron City
+- MUST Take the center in Celadon. Replenishes PP & sets Celadon as the warp point.
+- Bike East to Saffron City, trading Fresh Water for passage, and enter Silph Co.
 
 ## Saffron City
 
-- Enter Silph Co and take the stairs to floor 5
-- Get the [hidden Elixer](http://gunnermaniac.com/pokeworld?map=210#12/3)
+<img align="right" src="https://i.imgur.com/WAid12E.jpeg" height=200>
 
-**Rocket 1:**
-- Thrash
+- Enter Silph Co and take the stairs to floor 5
+- Walk left and get the [hidden Elixer](http://gunnermaniac.com/pokeworld?map=210#12/3) in the plant, then walk down and talk to the Rocket next to the teleport pad.
+
+**Rocket 1: Silph Arbok**
+- Thrash x2-3
 
 Get the Card Key
+
+<img align="right" src="https://i.imgur.com/MEpyFTQ.png" height=175>
 
 **Rival:**
 - Pidgeot:
@@ -488,7 +519,7 @@ Get the Card Key
 	- X Speed
 - HD x5
 
-Note: In this split we want to take a bit of damage to do a strat on Koga called Boom Strats
+> Note: In this split we want to take a bit of damage to do a strat on Koga called Boom Strats. We intentionally allow Koga's Weezing to KO Nido and we use our rare candies after exiting Koga's gym. The end result is that Nido holds safe red bar through the last 4 gym leaders and first two E4 members for several minutes of timesave.
 
 If 1-77, use an Elixer before the next fight
 
@@ -525,6 +556,8 @@ Menu before Snorlax:
 
 - Note: You can hold B to stop automatically moving down on Cycling Road
 - Get the [hidden Rare Candy](http://gunnermaniac.com/pokeworld?map=1#125/148)
+
+<img src="https://i.imgur.com/klM3YDH.jpeg">
 
 ## Fuschia City
 

--- a/docs/gen-1/red-blue/main-glitchless/classic-beginner-route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/classic-beginner-route/README.md
@@ -3,10 +3,11 @@
 ### Good Documents and Resources
 
 - [How To Speedrun Pokemon on Emulator](https://youtu.be/nf51DyXg-OY)
-- [Red Glitchless FAQ](https://pokemon-speedrunning.github.io/speedrun-routes/#/gen-1/red-blue/main-glitchless/resources/faq)
+- [Red Glitchless and Red Classic FAQ](https://pokemon-speedrunning.github.io/speedrun-routes/#/gen-1/red-blue/main-glitchless/resources/faq)
 - [Resources - Pokémon Red/Blue](https://www.speedrun.com/pkmnredblue/resources)
 	- Optional: Download "Red Classic Helper" and see [here](https://imgur.com/gallery/d9LGAo8) for beginner settings
 	- SAVES: Download "Any% Glitchless (Classic)"
+ 	- RBY Savestate Patcher can be used to make your own practice ROM
 
 ### Glossary
 
@@ -22,7 +23,7 @@
 
 - Clear any existing save file by pressing **Up + B + Select** on the game title screen
 - Hard Reset (set palette with Up + B - optional to give full visibility in Rock Tunnel), **hard resetting is required before each attempt on emulator**
-- Set your options to fast text and animations OFF
+- Set your options to Fast Text and Animations OFF
 
 ## NIDORAN SPLIT
 
@@ -587,7 +588,7 @@ Giovanni:
 
 Pick up Silph Scope, then open the menu:
 - 1-19 Potion (but do not use your last Potion, instead center after you dig out)
-- Dig out, fly to Lavender Town
+- Dig out, fly to Lavender Town (toggle down 3)
 
 ## FLUTE SPLIT
 
@@ -643,11 +644,11 @@ Get the Poke Flute from Mr. Fuji.
 
 ## KOGA SPLIT
 
-Walk out of his house, then Fly to Celadon.
+Walk out of his house, then Fly to Celadon (toggle down 1)
 
 Celadon City
 
-- MUST Take the center in Celadon. Replenishes PP & sets Celadon as the warp point.
+- MUST Take the center now in Celadon. Replenishes PP & sets Celadon as the warp point.
 - Bike East to Saffron City, trading Fresh Water for passage, and enter Silph Co.
 - Take the stairs up to 5F.
 - Walk left and take the hidden Elixer in the plant, then walk down and talk to the Rocket next to the teleport pad.
@@ -735,7 +736,7 @@ Safari Zone
 
 <img src="https://i.imgur.com/A8Qwy4y.png">
 
-Exit the house, dig out of the safari, fly back to Fuschia city, and walk to Koga’s gym.
+Exit the house, dig out of the safari, fly back to Fuschia city (toggle down 2), and walk to Koga’s gym.
 
 <img align="right" src="https://i.imgur.com/inIR2Ri.jpeg">
 
@@ -810,7 +811,7 @@ Take the stairs to the next room.
 
 ## BLAINE
 
-Fly to Cinnabar Island (down 2).
+Fly to Cinnabar Island (toggle down 2).
 
 - Blaine’s gym puzzle: A B B B A B (A=yes; B=no)
 
@@ -824,7 +825,7 @@ Dig out of Blaine’s gym.
 
 ## SABRINA
 
-Bike east to Sabrina’s gym by walking through the guard house.
+Bike East to [Sabrina’s gym](https://gunnermaniac.com/pokeworld?map=1#254/112/S) by walking through the guard house.
 
 Teleporter Puzzle: Diagonal, Diagonal, Down (bottom left)
 
@@ -843,7 +844,7 @@ Take the teleporter pad and then use Dig (causes animation to be faster).
 
 ## ERIKA
 
-Bike to Erika’s gym, avoid optionals inside by hugging the left wall and cut the top left tree.
+Bike to [Erika's Gym](https://gunnermaniac.com/pokeworld?map=1#162/136) and follow [this path](https://i.imgur.com/fWP9bAh.png) inside the gym to avoid optionals by hugging the left wall and cutting the top left tree.
 
 Beauty:
 - Exeggcute: IB
@@ -859,7 +860,7 @@ Exit Erika's gym by cutting the middle tree.
 
 ## GIOVANNI SPLIT
 
-Fly to Viridian City (up 1) and bike to Giovanni's gym.
+Fly to Viridian City (toggle up 1) and bike to Giovanni's gym.
 
 <img align="right" src="https://i.imgur.com/3JcpNQh.jpeg">
 

--- a/docs/gen-1/red-blue/main-glitchless/classic-beginner-route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/classic-beginner-route/README.md
@@ -349,6 +349,8 @@ Jr. Trainer♂:
 
 Enter the Mart.
 
+> Important note for shopping right now in Vermillion and later in Celadon: **always buy items in the order that they are listed in this guide**. Doing so is both the fastest way to buy the items and sets up our inventory in the correct order.
+
 Vermilion Mart
 - Sell all Poke Balls
 - Buy 3 Repels

--- a/docs/gen-1/red-blue/main-glitchless/intermediate-route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/intermediate-route/README.md
@@ -4,6 +4,7 @@
 - [Defensive Damage Ranges](../resources/defensive-ranges.md)
 - [Offensive Damage Ranges](../resources/offensive-ranges.md)
 - Not recommended for this route, but worth reading: [Advanced HP Strats](../resources/hp-strats.md)
+- This guide is still the 2 Max Ether Route, but it will likely be modified soon in favor of getting 1 Ether and 1 Max Ether. Feel free to make the following adjustments to more conistently have an extra blizzard for Agatha: https://pastebin.com/C0mesB6B
 
 ### Glossary
 - Moves: HA = Horn Attack, MP = Mega Punch, BB = Bubblebeam, WG = Water Gun, TB = Thunderbolt, Blizz = Blizzard, PS = Poison Sting, HD = Horn Drill, RS = Rock Slide
@@ -523,7 +524,10 @@ Use your Bike and go west to Snorlax
 > - In the 3rd Zone of the Safari - pick up [TM40](https://gunnermaniac.com/pokeworld?map=218#19/7) for bag space
 > - In the Surf menu - swap HM01 with X Speed
 
-**Menu**
+Menu:
+- Use Bike and cut both trees to enter Safari Zone
+
+**EQ Menu**
 - Use slot 4 **Repel**
 - Down 2 to swap **Potion** with **X Special** (3 below HM01)
 - Down 6 to teach **TM26** Earthquake in move slot 2 (over Thrash or RS)

--- a/docs/gen-1/red-blue/main-glitchless/intermediate-route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/intermediate-route/README.md
@@ -554,6 +554,17 @@ Koga:
 
 - If you didn't die from Koga you can still try to get red bar by following the [backups](https://pastebin.com/BMQQYcEV)
 
+| HP after SD on Koga | Red Bar Lost on... | Overview of Strategy                                                                                                       
+| ------------------- | ------------------ | -----------------------------------------------
+| 0-1                 | Machamp            | Normal Strats                                                                                                   
+| 2-4                 | Lapras             | Normal until Bruno; Use PP Item turn 2 on Bruno                                                   
+| *5-14               | ...                | Normal until Gio;  Blizz on Cooltrainer's Rhyhorn         
+| 5-6                 | Cloyster           | Elixer on Gio's Rhyhorn
+| 7-11                | Rhydon/Grolithe    | X-Spec on Gio's Nidoking
+| 12-14               | Machop             | Elixer on Gio's Nidoking
+| 15-22               | Rapidash/Venomoth  | Poké Flute on Vileplume                                                                                       
+| 23+                 | Exeggcute          | Poké Flute on Victreebel    
+
 ## ERIKA SPLIT
 
 Exit Koga's gym and **menu right away**
@@ -579,6 +590,11 @@ Mansion
 Pick up the Rare Candy and Secret Key then Dig out
 
 Bike to Erika's gym
+
+| HP On Exeggcute     | Overview of Strategy                                                                                                       
+| ------------------- | --------------------------------------                                            
+| 25-32               | Poké Flute on Vileplume until hit                                                                          
+| 33+                 | Poké Flute on Victreebel until hit   
 
 Beauty:
 - Blizz
@@ -610,25 +626,47 @@ Sabrina:
 Take the pad before Digging out, Fly to Viridian City, and Bike to the gym
 
 Cooltrainer:
-- EQ
+- EQ  or Blizz if you lived Weezing SD on 5-14
 
 Blackbelt:
 - X Acc + HD
 - Blizz
 - HD
 
+> Take note of your HP and your Blizzard count.
+
 Leave the gym and re-enter.
 
-**Menu** one step back into the gym
+Normally just **Menu** one step back into the gym
 - Use slot 6 - Elixer
 
-Note: You need to save at least 1 Blizzard for Agatha's Golbat so play accordingly
+> *Still use Elixer before Giovanni at 27-31 hp if 0 Blizz are left.
+
+## Giovanni
+
+| HP After Blackbelt | Overview of Strategy                                                                                                       
+| ------------------- | --------------------------------------    
+| 1-24               | Play Normal.
+| 25-26              | Rhyhorn: Elixer + Blizz or EQ, then play normal.
+| 27-31*             | Rhyhorn: Blizz (+EQ); Nidoking: X-Spec Turn 1 (+Elixer) (+TB), **EQ at any time if hit** (Elix on Rhydon if you haven't already)
+| 32+		     | Rhyhorn: Blizz / EQ;  Nidoking: Elixer Turn 1, (+X-Spec) (+TB), **EQ at any time if hit**
+
+> With 27+ HP after Blackbelt, be prepared to know what to do if you miss Blizzard on Gio's Rhyhorn.   
+> (1) If Rhyhorn **hits you or lands a tail whip**, always Elixer right away (if you didn't already before the fight).
+> (2) Otherwise, EQx3 and Elixer turn 1 on Nidoking even if this risks being KO'd by thrash.   
 
 Giovanni:
 - EQ x4
 - Blizz Rhydon until you have 2 Blizzard left (switch to EQ after that)
 
+> Note: You need to save at least 1 Blizzard for Agatha's Golbat so play accordingly
+
 ## LORELEI SPLIT
+
+| HP After Giovanni | Overview of Strategy                                                                                                       
+| ------------------- | --------------------------------------    
+| 1-27                | Play Normal.
+| 28+                 | modify Viridian Rival. Pidg: X-Acc, Blizz + TB, Rhyhorn: X-Speed + Horn Drill
 
 Super Repel + Bike as soon as you exit the gym
 
@@ -653,6 +691,8 @@ Lorelei:
 - Swap to Nidoking
 - X Acc + HD x5
 - Note: Option to swap Nidoking and bird pre-fight if you want to save 0-0.5s at the cost of being difficult
+
+> if you lost red bar on Lorelei, then delay using your PP Item until turn 2 on Onix
 
 ## BRUNO SPLIT
 

--- a/docs/gen-1/red-blue/main-glitchless/intermediate-route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/intermediate-route/README.md
@@ -4,7 +4,7 @@
 - [Defensive Damage Ranges](../resources/defensive-ranges.md)
 - [Offensive Damage Ranges](../resources/offensive-ranges.md)
 - Not recommended for this route, but worth reading: [Advanced HP Strats](../resources/hp-strats.md)
-- This guide is still the 2 Max Ether Route, but it will likely be modified soon in favor of getting 1 Ether and 1 Max Ether. Feel free to make the following adjustments to more conistently have an extra blizzard for Agatha: https://pastebin.com/C0mesB6B
+- This guide is still the 2 Max Ether Route, but it will likely be modified soon in favor of getting 1 Ether and 1 Max Ether. Feel free to make the following adjustments to more consistently have an extra blizzard for Agatha: https://pastebin.com/C0mesB6B
 
 ### Glossary
 - Moves: HA = Horn Attack, MP = Mega Punch, BB = Bubblebeam, WG = Water Gun, TB = Thunderbolt, Blizz = Blizzard, PS = Poison Sting, HD = Horn Drill, RS = Rock Slide

--- a/docs/gen-1/red-blue/main-glitchless/intermediate-route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/intermediate-route/README.md
@@ -640,7 +640,7 @@ Leave the gym and re-enter.
 Normally just **Menu** one step back into the gym
 - Use slot 6 - Elixer
 
-> *Still use Elixer before Giovanni at 27-31 hp if 0 Blizz are left.
+> Delay Elixer if 25+ HP, except still use Elixer before Giovanni at 27-31 hp if 0 Blizz are left.
 
 ## Giovanni
 

--- a/docs/gen-1/red-blue/main-glitchless/race-route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/race-route/README.md
@@ -546,7 +546,10 @@ Use your Bike and go west to Snorlax
 - Get the [hidden PP Up](https://gunnermaniac.com/pokeworld?map=1#127/206)
 
 ### Fuschia City
-**Menu**
+
+Bike to cut the bushes to get to Safari Zone
+
+**Menu** inside Safari Zone
 - Use **Super Repel**
 - Swap slot 8 **Potion** with **X Speed**
 - Teach TM26 (Earthquake) over slot 2 Thrash

--- a/docs/gen-1/red-blue/main-glitchless/resources/faq.md
+++ b/docs/gen-1/red-blue/main-glitchless/resources/faq.md
@@ -3,12 +3,12 @@
 ## What should I do if I want to run this game?
 
 Here are the first things you should do:
-- Play through the game casually so you know the basics of a Pokémon game.
+- Play through the game casually so you know the basics of a Pokémon game. [Strategy Wiki](https://strategywiki.org/wiki/Pok%C3%A9mon_Red_and_Blue#Table_of_Contents) is an excellent casual guide.
 - Join the [Gen 1-3 Pokémon Speedrunning Discord](https://www.speedrun.com/pokemon/thread/r7a65)
 - Watch [this run (as it uses the updated route)](https://www.youtube.com/watch?v=GR9HKr61HJY) to learn more about the speedrun
 - Decide what category you want to run and get a guide here (we recommend the beginner guides with revives):
 	- [Glitchless](../)
-	- [Classic](https://www.speedrun.com/pkmnredblue/guide/zuzgp)
+	- [Classic](../)
 - Start learning the game and have fun!
 
 ## What route should I use?
@@ -48,7 +48,7 @@ You can manipulate RNG in Pokémon Red, which is all done by hard resetting the 
 
 No actually! Only one simple RNG manipulation is needed to run this category, [Nidoran manip](nido-manip.md), and you can ignore all other manips until you know the route more (but Surge cans manip is also very simple).
 
-There is another category with no RNG manipulation: [Any% Glitchless (Classic)](https://www.speedrun.com/pkmnredblue/full_game#Any_Glitchless_Classic).
+There is another category with no RNG manipulation: [Any% Glitchless (Classic)](https://www.speedrun.com/pkmnredblue/guides/zuzgp).
 
 ## Why is my manip failing?
 

--- a/docs/gen-1/red-blue/main-glitchless/resources/hp-strats-for-races.md
+++ b/docs/gen-1/red-blue/main-glitchless/resources/hp-strats-for-races.md
@@ -367,6 +367,36 @@ Note that 1/39 rolls are selectively ignored in spots where healing has its own 
 | 15-22               | Rapidash/Venomoth  | Poké Flute Vileplume                                                                                            |
 | 23+                 | Exeggcute          | X Acc Victreebel if you have 2 extra, then Poké Flute until hit (can Blizz x3 after X Acc)                      |
 
+### Erika Split
+
+| HP On Exeggcute     | Overview of Strategy 
+| ------------------- | --------------------------------------                                            
+| 25-32               | Poké Flute on Vileplume until hit 
+| 33+                 | Poké Flute on Victreebel until hit
+
+### Giovanni Split
+
+If you lived on 5-14 HP from Weezing's SD, then 
+- Blizz Cooltrainer's Rhyhorn.
+- HD Machop if you have an extra HD and still need damage (to save a Blizzard).
+
+Before Giovanni
+- At 1-24 HP, always Elixer before the fight.
+- At 25+ HP, delay Elixer.
+> Except if 27-31 HP and 0 Blizz left, then Elixer before the fight.
+ 
+
+| HP After Blackbelt | Overview of Strategy  
+| ------------------- | --------------------------------------    
+| 1-24               | Play Normal.
+| 25-26              | Rhyhorn: Elixer + Blizz or EQ, then play normal.
+| 27-31*             | Rhyhorn: Blizz (+EQ); Nidoking: X-Spec Turn 1 (+Elixer) (+TB), **EQ at any time if hit**, Elixer Rhydon  (wait until bike menu if you have 1 Blizz)
+| 32+		     | Rhyhorn: Blizz / EQ;  Nidoking: Elixer Turn 1, (+X-Spec) (+TB), **EQ at any time if hit**
+
+> With 27+ HP after Blackbelt, be prepared to know what to do if you miss Blizzard on Gio's Rhyhorn.    
+> (1) If Rhyhorn **hits you or lands a tail whip**, always Elixer right away (if you didn't already before the fight).    
+> (2) Otherwise, EQx3 and Elixer turn 1 on Nidoking even if this risks being KO'd by thrash.    
+
 ### Lorelei Split
 
 #### Lorelei backup for Revive used post-Koga
@@ -383,7 +413,8 @@ Note that 1/39 rolls are selectively ignored in spots where healing has its own 
 | HP   | Strategy                                       |
 | ---- | ---------------------------------------------- |
 | 1-19 | Rare Candy now unless you need the jingle skip |
-| 20+  | Normal strats                                  |
+| 20-34  | Normal strats                                |
+| 35+ | delay PP item to turn 2 in fight, if desparate |
 
 ### Agatha Split
 

--- a/docs/gen-1/red-blue/main-glitchless/resources/hp-strats.md
+++ b/docs/gen-1/red-blue/main-glitchless/resources/hp-strats.md
@@ -263,7 +263,7 @@ you but can increase the chance of you dying.
 | 0-1                 | Machamp            | Normal strats                                                                                                   |
 | 2-4                 | Lapras             | Normal strats                                                                                                   | Elixer(+Blizz) Gio Rhyhorn, X Acc VR Rhyhorn, PP item turn two on Bruno
 | 5-6                 | Cloyster           | Blizz Cooltrainer, Elixer(+Blizz) Gio Rhyhorn, X Acc(+TB) VR Rhyhorn                                            | PP item turn two on Bruno
-| 7-11                | Rhydon/Growlithe   | Blizz Cooltrainer+Gio, X Spec(+Elixer + EQ or Blizz) Nidoking, Elixer Rhydon |
+| 7-11                | Rhydon/Growlithe   | Blizz Cooltrainer+Gio, X Spec(+Elixer + EQ or Blizz) Nidoking, Elixer Rhydon (wait until bike menu if you have 1 Blizz) |
 | 12-14               | Machop             | Blizz Cooltrainer+Gio, Elixer(+X Spec+TB) Nidoking                                                              |
 | 15-22               | Rapidash/Venomoth  | Poké Flute Vileplume                                                                                            |
 | 23+                 | Exeggcute          | Poké Flute Victreebel                                                                                           |

--- a/docs/gen-1/red-blue/main-glitchless/resources/hp-strats.md
+++ b/docs/gen-1/red-blue/main-glitchless/resources/hp-strats.md
@@ -263,7 +263,7 @@ you but can increase the chance of you dying.
 | 0-1                 | Machamp            | Normal strats                                                                                                   |
 | 2-4                 | Lapras             | Normal strats                                                                                                   | Elixer(+Blizz) Gio Rhyhorn, X Acc VR Rhyhorn, PP item turn two on Bruno
 | 5-6                 | Cloyster           | Blizz Cooltrainer, Elixer(+Blizz) Gio Rhyhorn, X Acc(+TB) VR Rhyhorn                                            | PP item turn two on Bruno
-| 7-11                | Rhydon/Growlithe   | Blizz Cooltrainer+Gio, X Spec(+Elixer+Blizz) Nidoking, Elixer Rhydon (wait until bike menu if you have 1 Blizz) |
+| 7-11                | Rhydon/Growlithe   | Blizz Cooltrainer+Gio, X Spec(+Elixer + EQ or Blizz) Nidoking, Elixer Rhydon |
 | 12-14               | Machop             | Blizz Cooltrainer+Gio, Elixer(+X Spec+TB) Nidoking                                                              |
 | 15-22               | Rapidash/Venomoth  | Poké Flute Vileplume                                                                                            |
 | 23+                 | Exeggcute          | Poké Flute Victreebel                                                                                           |


### PR DESCRIPTION
FAQ now includes a link to the Red/Blue Strategy Wiki
Lass/nolass routes have some helpful embedded images and more links to images.
Classic beginner now has links to some gym leader locations and more indicators for where to fly such as (toggle down X) 
Also improved lass/nolass description of Boom Strats to avoid ppl thinking they should use a revive after Weezing. 
Added a note that items should be bought in the order that they are listed in the guide. 