### PR TITLE
Important note for shopping: **always buy items in the order that they are listed in this guide**. Doing so is both the fastest way to buy the items and sets up our inventory in the correct order. 

### DIFF
--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/lass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/lass/README.md
@@ -276,6 +276,8 @@ Depending of your HP, you may fight the Gentleman in [this room](https://gunnerm
 | 2-8   | Do Gentleman                            |
 | 9-24  | Do Gentleman if you want to play safely |
 
+> Important note for shopping: **always buy items in the order that they are listed in this guide**. Doing so is both the fastest way to buy the items and sets up our inventory in the correct order.  
+
 Shopping:
 - Buy:
 	- 6 Repels

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/nolass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/nolass/README.md
@@ -294,6 +294,8 @@ Depending of your HP, you may fight the Gentleman in [this room](https://gunnerm
 | 2-8   | Do Gentleman                            |
 | 9-24  | Do Gentleman if you want to play safely |
 
+> Important note for shopping: **always buy items in the order that they are listed in this guide**. Doing so is both the fastest way to buy the items and sets up our inventory in the correct order.  
+
 Shopping:
 - Buy:
 	- 6 Repels

--- a/docs/gen-1/red-blue/main-glitchless/classic-beginner-route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/classic-beginner-route/README.md
@@ -344,7 +344,9 @@ Jr. Trainer♂:
 - Spearow: Thrash
 - Raticate: Thrash
 
-> 1-30 HP: Full Restore now
+> 1-30 HP: Full Restore now    
+
+> Important note for shopping: **always buy items in the order that they are listed in this guide**. Doing so is both the fastest way to buy the items and sets up our inventory in the correct order.   
 
 Enter the Mart.
 


### PR DESCRIPTION
This small note (placed right before Vermillion Mart) would likely prevent new runners from buying items out of order and will cut down on confusion with menus later on. I also hope that the wording would beg the follow up question of "why is it faster to over scroll in a mart" and "why is this the optimal inventory order"? There is simply not room to answer these questions in the guide, but this note should turn into a hidden homework assignment for anyone looking to understand why a given choice is optimal. After some investigation / comparison a new runner should see that over-scrolling in marts is simply fewer inputs overall so we do this cause it's just faster. 

I've seen some runners getting pretty good times, but still buying items out of order after doing many attempts so I hope this little note helps!