### PR TITLE
Updates to lass and nolass beginner red glitchless routes (+ Classic Adv quick fix)

### DIFF
--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/2024/lass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/2024/lass/README.md
@@ -1,0 +1,723 @@
+# Pokemon Red Glitchless Beginner Guide, Lass Version
+
+**FAQ: [Please read the FAQ before learning :)](../../resources/faq.md)**
+
+### Manip quick reference
+- Nidoran Manip:
+	- [Optimal](../../resources/nido-manip.md) (HIGHLY RECOMMENDED)
+	- [1 A Press](https://youtu.be/2bwQZ6jPxRE)
+- Mount Moon Manip:
+	- [Post Hiker Backup Paras](https://pastebin.com/j5gtY4cy) (recommended for first runs)
+		- [Older version](https://pastebin.com/7kcZu3g4) (easier path, but select yoloball)
+	- [Post Nerd Backup Paras](../../resources/postnerd-backup-paras.md)
+	- [Entr's Moon Manip](https://pastebin.com/jnj9j47S)
+- Surge Cans Manip:
+	- [Optimal](https://www.youtube.com/watch?v=8Pa2f2WxCe4)
+	- [Palette Cans](https://youtu.be/_tWhfBITf_g) (allows you to see through Rock Tunnel by changing the palette)
+	- [60/60 Cans](https://www.youtube.com/watch?v=T6pXrZ9_Vq0) (slightly slower, but great success chance)
+
+### Good documents
+- [Defensive Damage Ranges](../../resources/defensive-ranges.md)
+- [Offensive Damage Ranges](../../resources/offensive-ranges.md)
+- [Safety-oriented HP Strats](../../resources/hp-strats-for-races.md)
+
+### Glossary
+- Moves: HA = Horn Attack, MP = Mega Punch, BB = Bubblebeam, WG = Water Gun, TB = Thunderbolt, Blizz = Blizzard, PS = Poison Sting, HD = Horn Drill, RS = Rock Slide
+	- (+ MOVE): A situational move used to finish off a pokemon when a damage range is missed
+- IT = Instant Text
+
+### Before you start
+- Clear any existing save file by pressing Up + B + Select on the game title screen
+- Set your options to fast text and animations OFF
+
+## Pallet Town
+
+- Name yourself and rival 'A'
+- Pick Squirtle and name it 'A'
+
+**Rival 1:**
+- Tail Whip + spam Tackle
+
+## Viridian City
+
+Get XP from one encounter in Route 1
+- During the parcel quest kill one encounter from a level 2 Rat, level 3 Rat, or a level 2 Pidgey. You can fight level 3 Pidgeys but you will take a bit of damage if you have a lower attack (10-11 at level 6) Squirtle. This early XP will get you Bubble for Brock
+
+Shopping:
+- 4 Poke Balls (This does require you to get consistent at manip yoloballs, you can buy 5 and 1 less Potion later on)
+
+Nidoran Manip:
+- [Optimal (HIGHLY RECOMMENDED)](../../resources/nido-manip.md)
+- [1 A Press](https://youtu.be/qPzSWHyMuW8)
+
+Get the [hidden Tree Potion](https://gunnermaniac.com/pokeworld?map=1#54/166)
+
+## Viridian Forest
+
+- Walk [this path](http://gunnermaniac.com/pokeworld?map=51#17/47/UUUURURRRRRRRRUUUUUUUULUURRUUUUUUUUUUUULLUUUUUUUUAUUULLLLLLLLDDDDDDDLLLLUUUUUUUUUUUUULLLLLLDDDDDDDDDDDDDDDDDDDLLLLLLUUUA) in the forest and pick up the Antidote and the hidden Potion along the way
+
+**Weedle Guy:**
+- Tail Whip x2 + spam Tackle [1-6 Potion]
+- Check your leveled up stats after this fight, if you have 13 special you have bad special, if you have 14 or 15 you have good special
+
+If you were poisoned do the following:
+- Swap Nidoran and Squirtle (Nidoran should be the lead pokemon)
+- Antidote
+- 1-15 Potion
+
+## Pewter City
+
+Shopping:
+- 8 Potions
+
+If you weren't poisoned do the following:
+- Swap Nidoran and Squirtle (Nidoran should be the lead pokemon)
+- 1-15 Potion and toss Antidote
+- [OPTIONAL SAVE IF YOU HAVE BAD SPECIAL]
+
+**Brock:**
+- Geodude [1-8 Potion]
+	- Swap to Squirtle, then spam Bubble
+- Onix [1-12 Potion]
+	- Swap to Squirtle
+		- IF ONIX USES BIDE: Tail Whip x2
+	- Spam Bubble
+
+Options: Battle Style to Set before leaving Brock's gym
+
+## Route 3
+
+**Bug Catcher 1:**
+- Caterpie: Leer + HA x2 (+ Tackle)
+- Weedle: Leer + HA x2
+	- Leer + HA + Tackle if you got String Shot hit OR Tackle will always kill
+- Caterpie: HA x2 + Tackle
+
+Menu:
+- Potion to 28+
+- Toss Antidote if you still have it
+
+**Shorts Guy:**
+- Rat: [1-15 Potion]
+	- Leer + HA x2
+- Ekans: [1-4 Potion, or 1-5 at -2 defense]
+	- Leer + HA x2
+		- Potion turn 1 of Wrap if you don't live 4 or 5 turn Wrap
+
+**Bug Catcher 2:**
+- Weedle:
+	- HA x2
+- Kakuna:
+	- Spam HA, finish with Tackle
+- Caterpie: [1-5 Potion]
+	- HA x2
+- Metapod:
+	- HA x2 + Tackle
+
+Menu: Potion to 22+
+
+**Lass:** (this route also fights the optional lass)
+- HA x4
+
+**Bug Catcher 3:**
+- Caterpie:
+	- PS x2 (HA turn 2 if PS won't kill and you didn't get turn 1 String Shot hit)
+- Metapod:
+	- HA, PS, HA, PS (you really want at least 1 HA after this fight, if you are at 1 HA just PS)
+
+Route 3 grass:
+- Catch a flyer
+	- Tackle then toss a Ball at any flyer except L8 Pidgey where you HA then toss a Ball
+- Kill one encounter in the grass with HA except level 3 or level 7 Jigglypuffs to get Nidoran to level 15
+
+## Mount Moon
+
+- Do not learn a full Moon Manip for your first runs, start by learning [Post Hiker Backup Paras](https://pastebin.com/j5gtY4cy) (or the [older version](https://pastebin.com/7kcZu3g4)) and walk through the first floor normally ([movement map](https://i.imgur.com/xzgmNBk.jpeg)). You will choose later if you want to learn [Entr Moon](https://pastebin.com/jnj9j47S) (works with Lass) or [Route 3 Moon](https://pastebin.com/tggXpQRC) (slightly better, but does not work with Lass strats). There is also a [Post Nerd Backup Paras](../../resources/postnerd-backup-paras.md) you can learn.
+- Get [TM12 (Water Gun)](https://gunnermaniac.com/pokeworld?map=59#5/32), [Rare Candy](https://gunnermaniac.com/pokeworld?map=59#35/31), [Escape Rope](https://gunnermaniac.com/pokeworld?map=59#36/23), [TM01 (Mega Punch)](https://gunnermaniac.com/pokeworld?map=61#29/5) and [Moon Stone](https://gunnermaniac.com/pokeworld?map=59#2/2)
+- Avoid catching wild Paras as the catch is not guaranteed even at low HP, catch the manipped one instead
+
+Menu before walking in front of the Rocket:
+- Toss any remaining Poke Balls (ONLY IF YOU HAVE A PARAS)
+- Use Rare Candy
+- Teach TM12 (Water Gun) over Tackle (slot 2)
+- Use Moon Stone
+- Teach TM01 (Mega Punch) over Leer (slot 1)
+
+**Rocket:**
+- Rat: MP
+- Zubat: MP + PS (HA if Zubat used Leech Life, MP if Leech Life also crit)
+
+Talk to the Nerd
+
+**Super Nerd:** (if you are out of HA just MP instead)
+- Grimer: MP + HA [Note: Water Gun can kill if you get a good MP roll, if so use WG over MP or HA]
+- Voltorb: MP + PS
+- Koffing: HA + MP if you have an HA, otherwise MP x2
+
+If you still need Paras: [Post Nerd Backup Paras](../../resources/postnerd-backup-paras.md)
+
+## Nugget Bridge
+
+- Use the center
+- Get IT (Instant Text)
+	- You talk to the bike salesman and mash B through his text, this will set all text to instant. Things that kill instant text are Yes/No textboxes, opening the menu in and out of fights.
+- Pick up the [hidden Rare Candy](http://gunnermaniac.com/pokeworld?map=1#235/44)
+
+**Bridge Rival:**
+- Pidgeotto: HA x3 (if you get some bad rolls use MP to kill)
+	- If you get hit by 2 Sand-Attacks swap to your bird and let it die
+		- Try to put Pidgeotto in HA range before doing this to avoid getting Sand-Attacked again after swapping back
+		- Get IT again after the fight
+- Abra: HA
+- Rat: MP
+- Bulba: MP + HA (MP if you get Growled or miss a bunch into Leech Seed healing)
+
+**BC:**
+- MP (+ PS)
+- MP (if you missed MP into String Shot hit use HA)
+
+**Lass:**
+- MP (+ PS)
+- HA x2
+
+**Youngster:**
+- MP
+- MP (+ PS)
+- HA
+
+**Lass:**
+- MP (+ PS)
+- HA x2
+
+**Mankey:** [Note: Mankey is 1/3 to Karate Chop and does 12-15, healing is an option but is slow because you lose IT]
+- 1-7 MP (+ PS)
+- 8-27 HA x2 [Note: PS can kill if you get a good HA roll, if so use PS over the second HA]
+- 28+ MP (+ PS)
+
+**Rocket:**
+- Ekans: MP
+- Zubat: HA
+
+## Route 25
+
+**Bottom Hiker:**
+- WG
+
+**Lass:**
+- MP
+- HA x2
+
+**Hiker:**
+- WG
+- WG
+- MP (+ PS)
+- WG
+
+**Lass:**
+- MP
+	- Teach Thrash over Water Gun (slot 2)
+- Thrash
+
+Menu after Bill:
+- Use Rare Candy
+- Use Escape Rope
+
+## Cerulean City
+
+- Use the center
+- Get IT again
+
+**Dig Rocket:**
+- Thrash
+
+**Jr Trainer F:**
+- Thrash
+
+**Misty:**
+- Thrash
+	- If you are ever alive and confused swap to another poke (bird) and let it die
+
+If 1-15 after Misty (or 16-24 and you want to play safely):
+- Potion
+- Teach TM11 (Bubblebeam) over PS (slot 4)
+- Get IT again
+
+## Vermilion City
+
+**Jr Trainer F:**
+- Thrash
+
+**Jr Trainer M:**
+- Thrash
+
+If 1-12 after this fight:
+- Potion
+- Teach TM11 (Bubblebeam) over PS (slot 4)
+
+**Boat Rival:**
+- Pidgeotto:
+	- HA x2 (HA + BB if taught; Potion turn 2 if 1-6)
+	- If you get Sand-Attacked swap to another pokemon and let it die
+- Rat:
+	- 1-6 Potion
+	- 7-22 MP [Note: Potion on 7-12 is extra safe]
+	- 23+ HA + PS or BB x2
+- Kadabra:
+	- 1-6 HA Kadabra & Potion turn 1 on Ivysaur, then Thrash
+	- 7+ Thrash Kadabra
+
+Talk to the Captain to get HM01
+
+Depending of your HP, you may fight the Gentleman in [this room](https://gunnermaniac.com/pokeworld?map=96#21/11) with Thrash then pick up the Rare Candy
+
+| HP    | Strategy                                |
+| ----- | --------------------------------------- |
+| 1     | Skip Gentleman, use Potion in Cut Menu  |
+| 2-8   | Do Gentleman                            |
+| 9-24  | Do Gentleman if you want to play safely |
+
+> Important note for shopping: **always buy items in the order that they are listed in this guide**. Doing so is both the fastest way to buy the items and sets up our inventory in the correct order.  
+
+Shopping:
+- Buy:
+	- 6 Repels
+	- 4 Parlyz Heals
+
+Menu before Cut bush:
+- Teach TM11 (Bubblebeam) over PS (slot 4)
+- [Rare Candy if you fought the Gentleman]
+- Teach HM01 to Paras
+- Teach TM28 (Dig) to Paras
+- Use Cut
+
+Surge Cans Manip:
+- [Optimal](https://www.youtube.com/watch?v=8Pa2f2WxCe4)
+- [Palette Cans](https://youtu.be/_tWhfBITf_g) (allows you to see through Rock Tunnel by changing the palette)
+- [60/60 Cans](https://www.youtube.com/watch?v=T6pXrZ9_Vq0) (slightly slower, but great success chance)
+
+**Surge**
+- Voltorb:
+	- 1-24 Thrash
+	- 25+ BB + HA
+- Pikachu:
+	- Thrash
+- Raichu:
+	- If you are confused and dead to a self hit, swap to your bird or Squirtle
+
+Get the Bike Voucher and use Dig on Paras
+
+## Cerulean City
+
+- Get the Bike
+- Menu:
+	- Swap (using select) slot 1 with the Bike
+	- Teach TM24 (Thunderbolt) over HA (slot 3)
+	- Use the Bike
+
+## Route 9
+
+**4 Turn Thrash Girl:**
+- MP
+- Thrash
+	- If you run out of MP just Thrash, you will be 25% to hit yourself on the last poke
+
+**Bug Catcher:**
+- BB (Thrash if you fought the Gentleman)
+- Thrash
+
+## Rock Tunnel
+
+[Map of both floors](https://imgur.com/gallery/uoueIjq)
+
+Menu after taking 1 step down:
+- Scroll down and use a Repel
+
+**Pokemaniac 1:**
+- BB
+- TB
+
+**Pokemaniac 2:**
+- TB
+
+[Optional Save if 1-17 and you did not fight the Gentleman]
+
+**Oddish Girl:**
+- If you fought the Gentleman, Thrash. The ranges are guaranteed
+- 18-22 TB, then Thrash
+- Otherwise, just Thrash
+	- If you get put to sleep, Potion at 1-5
+	- If paralyzed, keep using Thrash
+
+After the fight:
+- Use one Repel [here](https://gunnermaniac.com/pokeworld?map=232#25/19)
+- Use another Repel [here](https://gunnermaniac.com/pokeworld?map=232#8/17)
+	- If you were paralyzed, use a Parlyz Heal now
+	- You can delay these 2 Repels up to ~10 tiles
+
+**Hiker:**
+- BB x3
+
+**Jr Trainer F:**
+- Thrash
+
+Get the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=21#16/53)
+
+## Route 8
+
+**Gambler:**
+- Growlithe:
+	- 1-8 Potion
+	- BB
+- Vulpix: Thrash
+
+## Underground
+
+- Get the [hidden Elixer](http://gunnermaniac.com/pokeworld?map=121#21/5)
+- Get the [hidden Nugget](http://gunnermaniac.com/pokeworld?map=121#12/2)
+
+## Celadon City
+
+Shopping:
+- Floor 2:
+	- Sell TM34
+	- Sell both Nuggets
+	- Buy TM07
+	- Buy 7 Super Repels
+	- Buy 4 Super Potions
+	- Buy 2 Revives
+- Floor 4:
+	- Buy Poke Doll
+- Roof:
+	- Buy a Soda Pop and trade it to the girl
+	- Come back and buy a Fresh Water
+- Floor 5:
+	- Buy 12 X Accs
+	- Buy 9 X Specs (7 if you have 0 Potions at this point)
+	- Buy 1 X Speeds (3 if you have 0 Potions at this point)
+
+Take the elevator and get HM02 (Fly)
+
+Menu after getting Fly:
+- Swap slot 2 with TM07
+- Use a Super Repel
+- Teach TM48 (Rock Slide) over Mega Punch (slot 1)
+- Swap slot 3 with X Accs
+- Teach HM02 to the bird
+- Use Fly to go to Lavender
+
+## Lavender Town
+
+Note: From this point on you have 2 Revives which means deaths aren't as scary, so if you die remember to swap to a pokemon, Revive, let the swapped pokemon die and ANY AND ALL X ITEMS ARE GONE. This route has extras so you shouldn't run out of X items, and there will still be some saving since some deaths with Revives are still really slow to come back from if at all.
+
+**Rival:**
+- Pidgeotto:
+	- 1-8 Potion (X Acc if you get Sand-Attacked)
+	- TB
+- TB
+- BB
+- Thrash
+
+[Tower Movement Map](https://imgur.com/gallery/Yf2tY3u)
+
+**Channeler 1:**
+- RS x2
+
+- Get the Elixers [here](http://gunnermaniac.com/pokeworld?map=145#12/10) and [here](http://gunnermaniac.com/pokeworld?map=146#4/12)
+
+**Channeler 2:**
+- RS
+
+**Channeler 3:**
+- RS
+
+
+- Pick up the Rare Candy in your way
+- Teach TM07 (Horn Drill) over Rock Slide (slot 1)
+
+**Ghost Encounter:**
+- Swap slot 3 with Super Repels
+- Use Poke Doll
+
+**Rocket 1:**
+- TB x3 (+ BB)
+
+**Rocket 2:**
+- X Acc + HD x2
+
+**Rocket 3:**
+- TB x2
+- Thrash
+
+Get the Poke Flute and Fly to Celadon City
+
+## Celadon City
+
+- Use the center
+- Bike to Saffron City
+
+## Saffron City
+
+- Enter Silph Co and take the stairs to floor 5
+- Get the [hidden Elixer](http://gunnermaniac.com/pokeworld?map=210#12/3)
+
+**Rocket 1:**
+- Thrash
+
+Get the Card Key
+
+**Rival:**
+- Pidgeot:
+	- X Acc
+	- If you were paralyzed on Arbok, use a Parlyz Heal
+	- X Speed
+- HD x5
+
+Note: In this split we want to take a bit of damage to do a strat on Koga called Boom Strats
+
+If 1-77, use an Elixer before the next fight
+
+**Rocket 2:**
+- Cubone:
+	- X Acc
+	- If Cubone damages you below 78 and you haven't used Elixer, use it now
+	- BB
+- Drowzee:
+	- If you haven't used Elixer, use it now
+	- HD
+- Marowak: HD
+
+**Giovanni:**
+- X Acc + HD
+- HD
+- BB
+- HD
+
+Go back to the elevator and go to the 10th Floor to get [TM26 (Earthquake)](https://gunnermaniac.com/pokeworld?map=234#2/12) and the [Rare Candy](https://gunnermaniac.com/pokeworld?map=234#4/14)
+
+Use Dig on Paras
+
+## Celadon City
+
+- Use your Bike and go to Snorlax
+
+Menu before Snorlax:
+- Use a Repel
+- Swap slot 5 (Parlyz Heal) for Rare Candies
+- Use Poke Flute
+
+## Cycling Road
+
+- Note: You can hold B to stop automatically moving down on Cycling Road
+- Get the [hidden Rare Candy](http://gunnermaniac.com/pokeworld?map=1#125/148)
+
+## Fuschia City
+
+Menu:
+- Use a Repel
+- Swap slot 6 (Potion) with X Spec (if 0 Potions, then swap Helix Fossil with X Spec instead)
+- Teach TM26 (Earthquake) over Thrash (slot 2)
+- Use Bike
+
+[Safari Movement Map](https://imgur.com/gallery/h9KpU3I)
+
+In the Safari Zone:
+- Super Repel on the 2nd map around [this tile](https://gunnermaniac.com/pokeworld?map=217#13/24)
+- Pick up the [Teeth](https://gunnermaniac.com/pokeworld?map=219#19/7) and get Surf
+- After getting Surf, Dig out of the safari and Fly back to Fuschia City
+
+**Juggler 1:**
+- EQ x4
+
+**Juggler 2:**
+- EQ
+- EQ + TB
+	- If TB gets disabled, finish with BB if it's in range, finish with EQ if not or you don't know the range
+
+**Koga:**
+- EQ x3
+- Elixer on Weezing
+	- If Koga used X Attack, scroll up 2 and use X Spec until you die
+	- If you didn't die from Koga you can still try to get red bar by following the [intermediate backups](https://docs.google.com/document/d/1_q5ddsyYnIKN48_UlokZw4mPmlMZLnTXDPihN_UQFwY/edit?usp=sharing). Note that this can be risky
+
+Menu after Koga:
+- Use all Rare Candies
+- Bike to get Strength
+- Fly to Pallet Town
+
+## Pallet Town
+
+Menu at the bottom of the water:
+- Super Repel
+- Teach HM03 (Surf) to Squirtle
+- Surf
+
+## Cinnabar Island
+
+- Pick up TM14 (Blizzard)
+- Menu:
+	- Teach HM04 (Strength) to Squirtle over Tackle (slot 1)
+	- Teach TM14 (Blizzard) over BB
+	- Use Repel (THIS IS THE **REPEL** NOT SUPER REPEL)
+- Pick up the [Rare Candy](http://gunnermaniac.com/pokeworld?map=216#10/2)
+- Pick up the [Secret Key](https://gunnermaniac.com/pokeworld?map=216#5/13)
+- Dig out
+
+## Celadon City
+
+Bike to the gym
+
+**Beauty:**
+- Blizz
+
+**Erika:**
+- EQ
+- Blizz
+- EQ
+
+Fly back to Cinnabar
+
+## Cinnabar Island
+
+Quiz answers: A B B B A B
+
+**Blaine:**
+- X Acc + EQ
+- HD x3
+
+Dig out and Bike to Sabrina's gym
+
+## Saffron City
+
+Teleporter puzzle: Top left, Bottom left, Bottom left
+
+**Sabrina:**
+- EQ x4
+
+Walk back to the teleporter and Dig out and Fly to
+
+## Viridian City
+
+**Cooltrainer:**
+- EQ
+
+[OPTIONAL SAVE: This next fight has a decent chance to die, and reviving will lose red bar so saving is advised]
+
+**Blackbelt:**
+- X Acc + HD
+- Blizz
+- HD
+
+Leave the gym to reset the trainer
+
+Menu after entering the gym again:
+- Elixer
+
+**Giovanni:**
+- EQ x4
+- Blizz (+ Blizz)
+	- Note: Don't go below 2 Blizzards in this fight, use EQ to finish Rhydon if you need to
+
+Menu after leaving the gym:
+- Super Repel
+- Bike
+
+**Rival:**
+- X Acc + Blizz + TB
+- HD x2
+- X Spec (on Growlithe)
+- HD x3
+	- Note: Only if you had 0 Potions in Celadon and bought 3 X Speeds do the following instead:
+	- X Acc + X Speed + Blizz (+ TB), HD x5
+	- Otherwise, the badge boost from the X Spec on Growlithe allows us to outspeed Alakazam.
+
+## Victory Road
+
+[Super Repel locations](https://imgur.com/gallery/laeW1PT) and [Victory Road map](https://imgur.com/gallery/vKQYRQZ)
+
+- Pick up the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=34#8/90) from the water
+- Use a Super Repel one step into the cave
+- Watch a top leaderboard run for how to do the Strength boulder puzzles
+- Use the 2nd Super Repel on [this tile](https://gunnermaniac.com/pokeworld?map=194#5/14) before using Strength
+- After dropping before the last boulder on [this tile](https://gunnermaniac.com/pokeworld?map=194#24/16):
+	- Use Strength
+	- Use a Max Ether on HD
+	- Super Repel
+	- Bike
+- Optional Safety: Pick up the [Full Restore](http://gunnermaniac.com/pokeworld?map=194#26/7)
+
+## E4
+
+Don't deposit extra pokes unless you have no more Revives
+
+**Lorelei:**
+- Dewgong:
+	- Swap to the bird turn 1
+	- Swap back to Nido and X Acc
+	- HD x5
+
+Before Bruno use a Max Ether on HD
+
+**Bruno:**
+- X Acc + HD x5
+
+Menu before Agatha:
+- 1-18 Super Potion + Potion
+- 19+ Super Potion
+	- If out of Potion, just Super Potion once
+- Rare Candy
+
+**Agatha:**
+- Gengar: X Spec + EQ
+	- If you get put to sleep use the Poke Flute, and if you get confused risk it since you would need to X Spec again if you swapped
+- Golbat: Blizz
+	- If you miss Blizz, and Golbat uses Haze, use
+		- 2x TB on Golbat
+		- Consider using a Super Potion on Arbok at 25-60 (or use X Speed if you bought 3)
+		- 25 HP and lower has red bar, and is usually worth taking the risk
+		- You are slower than the last Gengar, so it will have a turn to use a move on you
+	- If you miss Blizz, but Golbat doesn't use Haze, use Blizz again, or TB if out of Blizzards
+- EQ x3
+
+Menu before Lance:
+- Use Elixer
+- Heal using the chart below
+- [OPTIONAL SAVE: Lance is somewhat likely to kill you, so saving is recommended]
+
+HP      | ITEMS
+------- | ---------------------------
+4-6     | Super Potion x2 + Potion x2
+8-26    | Super Potion x2 + Potion
+27-48   | Super Potion x2
+49-56   | Super Potion + Potion x2
+57-76   | Super Potion + Potion
+77-98   | Super Potion
+99-106  | Potion x2
+107-126 | Potion
+
+If you don't have enough Potions, use the next healing option
+- Feel free to use your Full Restore if you picked it up and you want to play really safe
+
+**Lance:**
+- Gyarados: X Spec + TB
+- Dragonair 1: Blizz
+- Dragonair 2: X Spec + Blizz (use X Speed instead if you have one)
+- Aero: TB
+- Dragonite: Blizz
+
+After Lance:
+- Heal to 22+
+- [OPTIONAL SAVE: Saving for Champ can be good if you don't have a spare X Accuracy + X Special + Revive]
+
+**Champion:**
+- Pidgeot: X Spec
+	- If Pidgeot does NOT use Sky Attack turn 1:
+		- Pidgeot: X Acc + HD
+		- Alakazam: HD
+		- Rhydon: HD
+		- Gyarados: **TB**
+		- Arcanine: HD
+		- Venusaur: HD
+	- If Pidgeot begins to use Sky Attack turn 1 (*Pidgeot is glowing*):
+		- Pidgeot: **Blizz**
+		- Alakazam: **EQ**
+		- Rhydon: X Acc + HD x4

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/2024/nolass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/2024/nolass/README.md
@@ -1,0 +1,741 @@
+# Pokemon Red Glitchless Beginner Guide, No-Lass Version
+
+**FAQ: [Please read the FAQ before learning :)](../../resources/faq.md)**
+
+### Manip quick reference
+- Nidoran Manip:
+	- [Optimal](../../resources/nido-manip.md) (HIGHLY RECOMMENDED)
+	- [1 A Press](https://youtu.be/2bwQZ6jPxRE)
+- Mount Moon Manip:
+	- [Post Hiker Backup Paras](https://pastebin.com/j5gtY4cy) (recommended for first runs)
+		- [Older version](https://pastebin.com/7kcZu3g4) (easier path, but select yoloball)
+	- [Post Nerd Backup Paras](../../resources/postnerd-backup-paras.md)
+	- [Route 3 Moon Manip](https://pastebin.com/tggXpQRC)
+	- [Entr's Moon Manip](https://pastebin.com/jnj9j47S)
+- Surge Cans Manip:
+	- [Optimal](https://www.youtube.com/watch?v=8Pa2f2WxCe4)
+	- [Palette Cans](https://youtu.be/_tWhfBITf_g) (allows you to see through Rock Tunnel by changing the palette)
+	- [60/60 Cans](https://www.youtube.com/watch?v=T6pXrZ9_Vq0) (slightly slower, but great success chance)
+
+### Good documents
+- [Defensive Damage Ranges](../../resources/defensive-ranges.md)
+- [Offensive Damage Ranges](../../resources/offensive-ranges.md)
+- [Safety-oriented HP Strats](../../resources/hp-strats-for-races.md)
+
+### Glossary
+- Moves: HA = Horn Attack, MP = Mega Punch, BB = Bubblebeam, WG = Water Gun, TB = Thunderbolt, Blizz = Blizzard, PS = Poison Sting, HD = Horn Drill, RS = Rock Slide
+	- (+ MOVE): A situational move used to finish off a pokemon when a damage range is missed
+- IT = Instant Text
+
+### Before you start
+- Clear any existing save file by pressing Up + B + Select on the game title screen
+- Set your options to fast text and animations OFF
+
+## Pallet Town
+
+- Name yourself and rival 'A'
+- Pick Squirtle and name it 'A'
+
+**Rival 1:**
+- Tail Whip + spam Tackle
+
+## Viridian City
+
+Get XP from one encounter in Route 1
+- During the parcel quest kill one encounter from a level 2 Rat, level 3 Rat, or a level 2 Pidgey. You can fight level 3 Pidgeys but you will take a bit of damage if you have a lower attack (10-11 at level 6) Squirtle. This early XP will get you Bubble for Brock
+
+Shopping:
+- 4 Poke Balls (This does require you to get consistent at manip yoloballs, you can buy 5 and 1 less Potion later on)
+
+Nidoran Manip:
+- [Optimal (HIGHLY RECOMMENDED)](../../resources/nido-manip.md)
+- [1 A Press](https://youtu.be/qPzSWHyMuW8)
+
+Get the [hidden Tree Potion](https://gunnermaniac.com/pokeworld?map=1#54/166)
+
+## Viridian Forest
+
+- Walk [this path](http://gunnermaniac.com/pokeworld?map=51#17/47/UUUURURRRRRRRRUUUUUUUULUURRUUUUUUUUUUUULLUUUUUUUUAUUULLLLLLLLDDDDDDDLLLLUUUUUUUUUUUUULLLLLLDDDDDDDDDDDDDDDDDDDLLLLLLUUUA) in the forest and pick up the Antidote and the hidden Potion along the way
+
+**Weedle Guy:**
+- Tail Whip x2 + spam Tackle [1-6 Potion]
+- Check your leveled up stats after this fight, if you have 13 special you have bad special, if you have 14 or 15 you have good special
+
+If you were poisoned do the following:
+- Swap Nidoran and Squirtle (Nidoran should be the lead pokemon)
+- Antidote
+- 1-15 Potion
+
+## Pewter City
+
+Shopping:
+- 8 Potions
+
+If you weren't poisoned do the following:
+- Swap Nidoran and Squirtle (Nidoran should be the lead pokemon)
+- 1-15 Potion and toss Antidote
+- [OPTIONAL SAVE IF YOU HAVE BAD SPECIAL]
+
+**Brock:**
+- Geodude [1-8 Potion]
+	- Swap to Squirtle, then spam Bubble
+- Onix [1-12 Potion]
+	- Swap to Squirtle
+		- IF ONIX USES BIDE: Tail Whip x2
+	- Spam Bubble
+
+Options: Battle Style to Set before leaving Brock's gym
+
+## Route 3
+
+**Bug Catcher 1:**
+- Caterpie: Leer + HA x2 (+ Tackle)
+- Weedle: Leer + HA x2
+	- Leer + HA + Tackle if you got String Shot hit OR Tackle will always kill
+- Caterpie: Leer + HA + Tackle
+
+Menu:
+- Potion to 28+
+- Toss Antidote if you still have it
+
+**Shorts Guy:**
+- Rat: [1-15 Potion]
+	- Leer + HA x2
+- Ekans: [1-4 Potion, or 1-5 at -2 defense]
+	- Leer + HA x2
+		- Potion turn 1 of Wrap if you don't live 4 or 5 turn Wrap
+
+**Bug Catcher 2:**
+- Weedle:
+	- HA x2 (Tackle is a range to kill turn 2)
+- Kakuna:
+	- Spam HA, finish with Tackle
+- Caterpie: [1-5 Potion]
+	- HA x2 (Tackle turn 2 if Weedle hit 2 String Shots)
+- Metapod:
+	- HA x2 + Tackle
+
+1-5 Potion x2 before next fight
+
+**Bug Catcher 3:**
+- Caterpie:
+	- HA x2
+- Metapod: (Note: You need at least 2 HAs for after this fight)
+	- Spam HA, finish with Tackle
+
+Catch a flyer:
+- Tackle then toss a Ball at any flyer except L8 Pidgey where you HA then toss a Ball
+- Exception: If only 2 HAs are left, then weaken L8 Pidgey with Leer + Tackle
+
+## Mount Moon
+
+- Do not learn a full Moon Manip for your first runs, start by learning [Post Hiker Backup Paras](https://pastebin.com/j5gtY4cy) (or the [older version](https://pastebin.com/7kcZu3g4)) and walk through the first floor normally ([movement map](https://i.imgur.com/xzgmNBk.jpeg)). You will choose later if you want to learn [Route 3 Moon](https://pastebin.com/tggXpQRC) (optimal for this route) or [Entr Moon](https://pastebin.com/jnj9j47S) (slightly less optimal, but still perfectly fine). There is also a [Post Nerd Backup Paras](../../resources/postnerd-backup-paras.md) you can learn.
+- Get [TM12 (Water Gun)](https://gunnermaniac.com/pokeworld?map=59#5/32), [Rare Candy](https://gunnermaniac.com/pokeworld?map=59#35/31), [Escape Rope](https://gunnermaniac.com/pokeworld?map=59#36/23), [TM01 (Mega Punch)](https://gunnermaniac.com/pokeworld?map=61#29/5) and [Moon Stone](https://gunnermaniac.com/pokeworld?map=59#2/2)
+- Avoid catching wild Paras as the catch is not guaranteed even at low HP, catch the manipped one instead
+
+Menu before walking in front of the Rocket:
+- Toss any remaining Poke Balls (ONLY IF YOU HAVE A PARAS)
+- Potion to 36+
+- (Optional but recommended) Save
+
+**Rocket:**
+- This fight will change depending on how many Horn Attacks you have left
+- 1 HA:
+	- Rat: Leer + Tackle x2 (+ PS)
+	- Zubat: Leer + Tackle + HA (+ Tackle)
+- 2 HA:
+	- Rat: Leer + HA + Tackle (or PS turn 3 if Tail Whip hit or PS always kills)
+	- Zubat: Leer + Tackle + HA (+ Tackle)
+- 3 HA:
+	- Rat: HA x2 (+ PS)
+	- Zubat: Leer + Tackle + HA (+ Tackle)
+- 4 HA:
+	- Rat: HA x2 (+ PS)
+	- Zubat: Leer + HA x2
+- 5+ HA:
+	- Rat: HA x2 (+ PS)
+	- Zubat: HA x3 (+ Tackle)
+
+Menu after defeating Rocket:
+- Use Rare Candy
+- Teach TM12 (Water Gun) over Tackle (slot 2)
+- Use Moon Stone
+- Teach TM01 (Mega Punch) over Leer (slot 1)
+
+Talk to the Nerd
+
+**Super Nerd:** (if you are out of HA just MP instead)
+- Grimer: MP + HA [Note: Water Gun can kill if you get a good MP roll, if so use WG over MP or HA]
+- Voltorb: MP + PS
+- Koffing: HA + MP if you have an HA, otherwise MP x2
+
+If you encounter a Paras or a Geodude, faint it for EXP (PS for Paras, WG for Geodude). This [Moon EXP](https://pastebin.com/8gP8HZY9) will improve some ranges.
+
+If you still need Paras: [Post Nerd Backup Paras](../../resources/postnerd-backup-paras.md)
+
+## Nugget Bridge
+
+- Use the center
+- Get IT (Instant Text)
+	- You talk to the bike salesman and mash B through his text, this will set all text to instant. Things that kill instant text are Yes/No textboxes, opening the menu in and out of fights.
+- Pick up the [hidden Rare Candy](http://gunnermaniac.com/pokeworld?map=1#235/44)
+
+**Bridge Rival:**
+- Pidgeotto: HA x3 (if you get some bad rolls use MP to kill)
+	- If you get hit by 2 Sand-Attacks swap to your bird and let it die
+		- Try to put Pidgeotto in HA range before doing this to avoid getting Sand-Attacked again after swapping back
+		- Get IT again after the fight
+- Abra: HA
+- Rat: MP
+- Bulba: MP + HA (MP if you get Growled or miss a bunch into Leech Seed healing)
+
+**BC:**
+- MP (+ PS)
+- MP (if you missed MP into String Shot hit use HA)
+
+**Lass:**
+- MP (+ PS)
+- HA x2
+
+**Youngster:**
+- MP
+- MP (+ PS)
+- MP (HA if you fought the extra Moon encounter)
+
+**Lass:**
+- MP (+ PS)
+- HA x2
+
+**Mankey:** [Note: Mankey is 1/3 to Karate Chop and does 12-15, healing is an option but is slow because you lose IT]
+- 1-7 MP (+ PS)
+- 8-27 HA x2 [Note: PS can kill if you get a good HA roll, if so use PS over the second HA]
+- 28+ MP (+ PS)
+
+**Rocket:**
+- MP
+- MP (HA if you fought the extra Moon encounter)
+
+## Route 25
+
+**Bottom Hiker:**
+- WG
+
+**Lass:**
+- MP
+- HA x2
+
+**Hiker:**
+- WG
+- WG
+- MP (+ PS)
+- WG
+
+**Lass:**
+- MP
+- HA
+- MP (HA if you fought the extra Moon encounter)
+	- Teach Thrash over Water Gun (slot 2)
+
+Menu after Bill:
+- Use Rare Candy
+- Use Escape Rope
+
+## Cerulean City
+
+- Use the center
+- Get IT again
+
+**Dig Rocket:**
+- Thrash
+
+**Jr Trainer F:**
+- Thrash
+
+**Misty:**
+- Thrash
+	- If you are ever alive and confused swap to another poke (bird) and let it die
+
+If 1-15 after Misty (or 16-24 and you want to play safely):
+- Potion
+- Teach TM11 (Bubblebeam) over PS (slot 4)
+- Get IT again
+
+## Vermilion City
+
+**Jr Trainer F:**
+- Thrash
+
+**Jr Trainer M:**
+- Thrash
+
+If 1-12 after this fight:
+- Potion
+- Teach TM11 (Bubblebeam) over PS (slot 4)
+
+**Boat Rival:**
+- Pidgeotto:
+	- HA x2 (HA + BB if taught; Potion turn 2 if 1-6)
+	- If you get Sand-Attacked swap to another pokemon and let it die
+- Rat:
+	- 1-6 Potion
+	- 7-22 MP [Note: Potion on 7-12 is extra safe]
+	- 23+ HA + PS or BB x2
+- Kadabra:
+	- 1-6 HA Kadabra & Potion turn 1 on Ivysaur, then Thrash
+	- 7+ Thrash Kadabra
+
+Talk to the Captain to get HM01
+
+Depending of your HP, you may fight the Gentleman in [this room](https://gunnermaniac.com/pokeworld?map=96#21/11) with Thrash then pick up the Rare Candy
+
+| HP    | Strategy                                |
+| ----- | --------------------------------------- |
+| 1     | Skip Gentleman, use Potion in Cut Menu  |
+| 2-8   | Do Gentleman                            |
+| 9-24  | Do Gentleman if you want to play safely |
+
+> Important note for shopping: **always buy items in the order that they are listed in this guide**. Doing so is both the fastest way to buy the items and sets up our inventory in the correct order.  
+
+Shopping:
+- Buy:
+	- 6 Repels
+	- 4 Parlyz Heals
+
+Menu before Cut bush:
+- Teach TM11 (Bubblebeam) over PS (slot 4)
+- [Rare Candy if you fought the Gentleman]
+- Teach HM01 to Paras
+- Teach TM28 (Dig) to Paras
+- Use Cut
+
+Surge Cans Manip:
+- [Optimal](https://www.youtube.com/watch?v=8Pa2f2WxCe4)
+- [Palette Cans](https://youtu.be/_tWhfBITf_g) (allows you to see through Rock Tunnel by changing the palette)
+- [60/60 Cans](https://www.youtube.com/watch?v=T6pXrZ9_Vq0) (slightly slower, but great success chance)
+
+**Surge**
+- Voltorb:
+	- 1-24 Thrash
+	- 25+ BB + HA
+- Pikachu:
+	- Thrash
+- Raichu:
+	- If you are confused and dead to a self hit, swap to your bird or Squirtle
+
+Get the Bike Voucher and use Dig on Paras
+
+## Cerulean City
+
+- Get the Bike
+- Menu:
+	- Swap (using select) slot 1 with the Bike
+	- Teach TM24 (Thunderbolt) over HA (slot 3)
+	- Use the Bike
+
+## Route 9
+
+**4 Turn Thrash Girl:**
+- MP
+- Thrash
+	- If you run out of MP just Thrash, you will be 25% to hit yourself on the last poke
+
+**Bug Catcher:**
+- BB (Thrash if you fought the Gentleman)
+- Thrash
+
+## Rock Tunnel
+
+[Map of both floors](https://imgur.com/gallery/uoueIjq)
+
+Menu after taking 1 step down:
+- Scroll down and use a Repel
+
+**Pokemaniac 1:**
+- BB
+- TB
+
+**Pokemaniac 2:**
+- TB
+
+[Optional Save if 1-17 and you did not fight the Gentleman]
+
+**Oddish Girl:**
+- If you fought the Gentleman, Thrash. The ranges are guaranteed
+- 18-22 TB + Thrash
+- Otherwise, just Thrash
+	- If you get put to sleep, Potion at 1-5
+	- If paralyzed, keep using Thrash
+
+After the fight:
+- Use one Repel [here](https://gunnermaniac.com/pokeworld?map=232#25/19)
+- Use another Repel [here](https://gunnermaniac.com/pokeworld?map=232#8/17)
+	- If you were paralyzed, use a Parlyz Heal now
+	- You can delay these 2 Repels up to ~10 tiles
+
+**Hiker:**
+- BB x3
+
+**Jr Trainer F:**
+- Thrash
+
+Get the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=21#16/53)
+
+## Route 8
+
+**Gambler:**
+- Growlithe:
+	- 1-8 Potion
+	- BB
+- Vulpix: Thrash
+
+## Underground
+
+- Get the [hidden Elixer](http://gunnermaniac.com/pokeworld?map=121#21/5)
+- Get the [hidden Nugget](http://gunnermaniac.com/pokeworld?map=121#12/2)
+
+## Celadon City
+
+Shopping:
+- Floor 2:
+	- Sell TM34
+	- Sell both Nuggets
+	- Buy TM07
+	- Buy 7 Super Repels
+	- Buy 4 Super Potions
+	- Buy 2 Revives
+- Floor 4:
+	- Buy Poke Doll
+- Roof:
+	- Buy a Soda Pop and trade it to the girl
+	- Come back and buy a Fresh Water
+- Floor 5:
+	- Buy 12 X Accs
+	- Buy 9 X Specs (7 if you have 0 Potions at this point)
+	- Buy 1 X Speeds (3 if you have 0 Potions at this point)
+
+Take the elevator and get HM02 (Fly)
+
+Menu after getting Fly:
+- Swap slot 2 with TM07
+- Use a Super Repel
+- Teach TM48 (Rock Slide) over Mega Punch (slot 1)
+- Swap slot 3 with X Accs
+- Teach HM02 to the bird
+- Use Fly to go to Lavender
+
+## Lavender Town
+
+Note: From this point on you have 2 Revives which means deaths aren't as scary, so if you die remember to swap to a pokemon, Revive, let the swapped pokemon die and ANY AND ALL X ITEMS ARE GONE. This route has extras so you shouldn't run out of X items, and there will still be some saving since some deaths with Revives are still really slow to come back from if at all.
+
+**Rival:**
+- Pidgeotto:
+	- 1-8 Potion (X Acc if you get Sand-Attacked)
+	- TB
+- TB
+- BB
+- Thrash
+
+[Tower Movement Map](https://imgur.com/gallery/Yf2tY3u)
+
+**Channeler 1:**
+- RS x2
+
+- Get the Elixers [here](http://gunnermaniac.com/pokeworld?map=145#12/10) and [here](http://gunnermaniac.com/pokeworld?map=146#4/12)
+
+**Channeler 2:**
+- RS
+
+**Channeler 3:**
+- RS
+
+
+- Pick up the Rare Candy in your way
+- Teach TM07 (Horn Drill) over Rock Slide (slot 1)
+
+**Ghost Encounter:**
+- Swap slot 3 with Super Repels
+- Use Poke Doll
+
+**Rocket 1:**
+- TB x3 (+ BB)
+
+**Rocket 2:**
+- X Acc + HD x2
+
+**Rocket 3:**
+- TB x2
+- Thrash
+
+Get the Poke Flute and Fly to Celadon City
+
+## Celadon City
+
+- Use the center
+- Bike to Saffron City
+
+## Saffron City
+
+- Enter Silph Co and take the stairs to floor 5
+- Get the [hidden Elixer](http://gunnermaniac.com/pokeworld?map=210#12/3)
+
+**Rocket 1:**
+- Thrash
+
+Get the Card Key
+
+**Rival:**
+- Pidgeot:
+	- X Acc
+	- If you were paralyzed on Arbok, use a Parlyz Heal
+	- X Speed
+- HD x5
+
+Note: In this split we want to take a bit of damage to do a strat on Koga called Boom Strats
+
+If 1-77, use an Elixer before the next fight
+
+**Rocket 2:**
+- Cubone:
+	- X Acc
+	- If Cubone damages you below 78 and you haven't used Elixer, use it now
+	- BB
+- Drowzee:
+	- If you haven't used Elixer, use it now
+	- HD
+- Marowak: HD
+
+**Giovanni:**
+- X Acc + HD
+- HD
+- BB
+- HD
+
+Go back to the elevator and go to the 10th Floor to get [TM26 (Earthquake)](https://gunnermaniac.com/pokeworld?map=234#2/12) and the [Rare Candy](https://gunnermaniac.com/pokeworld?map=234#4/14)
+
+Use Dig on Paras
+
+## Celadon City
+
+- Use your Bike and go to Snorlax
+
+Menu before Snorlax:
+- Use a Repel
+- Swap slot 5 (Parlyz Heal) for Rare Candies
+- Use Poke Flute
+
+## Cycling Road
+
+- Note: You can hold B to stop automatically moving down on Cycling Road
+- Get the [hidden Rare Candy](http://gunnermaniac.com/pokeworld?map=1#125/148)
+
+## Fuschia City
+
+Menu:
+- Use a Repel
+- Swap slot 6 (Potion) with X Spec (if 0 Potions, then swap Helix Fossil with X Spec instead)
+- Teach TM26 (Earthquake) over Thrash (slot 2)
+- Use Bike
+
+[Safari Movement Map](https://imgur.com/gallery/h9KpU3I)
+
+In the Safari Zone:
+- Super Repel on the 2nd map around [this tile](https://gunnermaniac.com/pokeworld?map=217#13/24)
+- Pick up the [Teeth](https://gunnermaniac.com/pokeworld?map=219#19/7) and get Surf
+- After getting Surf, Dig out of the safari and Fly back to Fuschia City
+
+**Juggler 1:**
+- EQ x4
+
+**Juggler 2:**
+- EQ
+- EQ + TB
+	- If TB gets disabled, finish with BB if it's in range, finish with EQ if not or you don't know the range
+
+**Koga:**
+- EQ x3
+- Elixer on Weezing
+	- If Koga used X Attack, scroll up 2 and use X Spec until you die
+	- If you didn't die from Koga you can still try to get red bar by following the [intermediate backups](https://docs.google.com/document/d/1_q5ddsyYnIKN48_UlokZw4mPmlMZLnTXDPihN_UQFwY/edit?usp=sharing). Note that this can be risky
+
+Menu after Koga:
+- Use all Rare Candies
+- Bike to get Strength
+- Fly to Pallet Town
+
+## Pallet Town
+
+Menu at the bottom of the water:
+- Super Repel
+- Teach HM03 (Surf) to Squirtle
+- Surf
+
+## Cinnabar Island
+
+- Pick up TM14 (Blizzard)
+- Menu:
+	- Teach HM04 (Strength) to Squirtle over Tackle (slot 1)
+	- Teach TM14 (Blizzard) over BB
+	- Use Repel (THIS IS THE **REPEL** NOT SUPER REPEL)
+- Pick up the [Rare Candy](http://gunnermaniac.com/pokeworld?map=216#10/2)
+- Pick up the [Secret Key](https://gunnermaniac.com/pokeworld?map=216#5/13)
+- Dig out
+
+## Celadon City
+
+Bike to the gym
+
+**Beauty:**
+- Blizz
+
+**Erika:**
+- EQ
+- Blizz
+- EQ
+
+Fly back to Cinnabar
+
+## Cinnabar Island
+
+Quiz answers: A B B B A B
+
+**Blaine:**
+- X Acc + EQ
+- HD x3
+
+Dig out and Bike to Sabrina's gym
+
+## Saffron City
+
+Teleporter puzzle: Top left, Bottom left, Bottom left
+
+**Sabrina:**
+- EQ x4
+
+Walk back to the teleporter and Dig out and Fly to
+
+## Viridian City
+
+**Cooltrainer:**
+- EQ
+
+[OPTIONAL SAVE: This next fight has a decent chance to die, and reviving will lose red bar so saving is advised]
+
+**Blackbelt:**
+- X Acc + HD
+- Blizz
+- HD
+
+Leave the gym to reset the trainer
+
+Menu after entering the gym again:
+- Elixer
+
+**Giovanni:**
+- EQ x4
+- Blizz (+ Blizz)
+	- Note: Don't go below 2 Blizzards in this fight, use EQ to finish Rhydon if you need to
+
+Menu after leaving the gym:
+- Super Repel
+- Bike
+
+**Rival:**
+- X Acc + Blizz + TB
+- HD x2
+- X Spec (on Growlithe)
+- HD x3
+	- Note: Only if you had 0 Potions in Celadon and bought 3 X Speeds do the following instead:
+	- X Acc + X Speed + Blizz (+ TB), HD x5
+	- Otherwise, the badge boost from the X Spec on Growlithe allows us to outspeed Alakazam.
+
+## Victory Road
+
+[Super Repel locations](https://imgur.com/gallery/laeW1PT) and [Victory Road map](https://imgur.com/gallery/vKQYRQZ)
+
+- Pick up the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=34#8/90) from the water
+- Use a Super Repel one step into the cave
+- Watch a top leaderboard run for how to do the Strength boulder puzzles
+- Use the 2nd Super Repel on [this tile](https://gunnermaniac.com/pokeworld?map=194#5/14) before using Strength
+- After dropping before the last boulder on [this tile](https://gunnermaniac.com/pokeworld?map=194#24/16):
+	- Use Strength
+	- Use a Max Ether on HD
+	- Super Repel
+	- Bike
+- Optional Safety: Pick up the [Full Restore](http://gunnermaniac.com/pokeworld?map=194#26/7)
+
+## E4
+
+Don't deposit extra pokes unless you have no more Revives
+
+**Lorelei:**
+- Dewgong:
+	- Swap to the bird turn 1
+	- Swap back to Nido and X Acc
+	- HD x5
+
+Before Bruno use a Max Ether on HD
+
+**Bruno:**
+- X Acc + HD x5
+
+Menu before Agatha:
+- 1-18 Super Potion + Potion
+- 19+ Super Potion
+	- If out of Potion, just Super Potion once
+- Rare Candy
+
+**Agatha:**
+- Gengar: X Spec + EQ
+	- If you get put to sleep use the Poke Flute, and if you get confused risk it since you would need to X Spec again if you swapped
+- Golbat: Blizz
+	- If you miss Blizz, and Golbat uses Haze, use
+		- 2x TB on Golbat
+		- Consider using a Super Potion on Arbok at 25-60 (or use X Speed if you bought 3)
+		- 25 HP and lower has red bar, and is usually worth taking the risk
+		- You are slower than the last Gengar, so it will have a turn to use a move on you
+	- If you miss Blizz, but Golbat doesn't use Haze, use Blizz again, or TB if out of Blizzards
+- EQ x3
+
+Menu before Lance:
+- Use Elixer
+- Heal using the chart below
+- [OPTIONAL SAVE: Lance is somewhat likely to kill you, so saving is recommended]
+
+HP      | ITEMS
+------- | ---------------------------
+4-6     | Super Potion x2 + Potion x2
+8-26    | Super Potion x2 + Potion
+27-48   | Super Potion x2
+49-56   | Super Potion + Potion x2
+57-76   | Super Potion + Potion
+77-98   | Super Potion
+99-106  | Potion x2
+107-126 | Potion
+
+If you don't have enough Potions, use the next healing option
+- Feel free to use your Full Restore if you picked it up and you want to play really safe
+
+**Lance:**
+- Gyarados: X Spec + TB
+- Dragonair 1: Blizz
+- Dragonair 2: X Spec + Blizz (use X Speed instead if you have one)
+- Aero: TB
+- Dragonite: Blizz
+
+After Lance:
+- Heal to 22+
+- [OPTIONAL SAVE: Saving for Champ can be good if you don't have a spare X Accuracy + X Special + Revive]
+
+**Champion:**
+- Pidgeot: X Spec
+	- If Pidgeot does NOT use Sky Attack turn 1:
+		- Pidgeot: X Acc + HD
+		- Alakazam: HD
+		- Rhydon: HD
+		- Gyarados: **TB**
+		- Arcanine: HD
+		- Venusaur: HD
+	- If Pidgeot begins to use Sky Attack turn 1 (*Pidgeot is glowing*):
+		- Pidgeot: **Blizz**
+		- Alakazam: **EQ**
+		- Rhydon: X Acc + HD x4

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/lass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/lass/README.md
@@ -221,7 +221,7 @@ If you were not poisoned, then menu one step into Brock's Gym:
 - Use Moon Stone
 - Teach TM01 (Mega Punch) over Leer (slot 1)
 
-#### Moon Rocket (HA Count Remaining --> Strategy):
+#### Moon Rocket:
 - Rattata
      - MP
 - Zubat

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/lass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/lass/README.md
@@ -33,9 +33,9 @@
 	- (+ MOVE): A situational move used to finish off a pokemon when a damage range is missed
 - IT = Instant Text
 
-### Important Note
+### Important Notes
 - When learning a new move you cannot hit up to make the cursor wrap around to the bottom slot like you can in battle. For example, to teach over Slot 4, you must press down three times. Don't accidentally delete the wrong move.
-- Victory Road can be tricky. While there will be an image embedded showing the optimal strategy, we recommended watching this [easier version of Victory Road / Lorelei Segment Movement](https://youtu.be/AbekvWHeX50). In the description there are timestamps and a link to a video of the optimal movement (~5 seconds faster). 
+- Practice the Lorelei split/segment (Victory Road movement, in particular) - watch and replicate either the [optimal Super Repel locations](https://youtu.be/Dq05fXW7k-4) or this [easier version of Victory Road / Lorelei Segment](https://youtu.be/AbekvWHeX50) (~5 seconds slower).
      - This guide assumes that you will use the optimal strategy in Victory Road, going slower/safer is optional. Note that the slower strategy still works if you accidentally wasted a Super Repel earlier, so it is worth knowing as a backup. 
 
 ### Before you start
@@ -465,7 +465,7 @@ Walk into the bike shop, get the Bike, and exit the shop.
 - MP (Thrash if 0 MP are left)
 - Thrash x3
      - if confused, typically just use Thrash to yolo 
-     - if confused + fought the Gentleman on boat, then you can swap + swap back to split exp with another poke
+     - or you can swap to another poke + swap back right away (splitting EXP here is fine)
 
 **Bug Catcher:**
 - BB (Thrash if you fought the Gentleman)
@@ -483,7 +483,7 @@ Walk into the bike shop, get the Bike, and exit the shop.
 - **Pokemaniac 1**: BB, TB
 - **Pokemaniac 2**: TB
 
-> Save before Oddish Girl if **under 43 HP**.      
+> Optional - Save before Oddish Girl if **under 43 HP**.      
 > Gentleman --> Always skip save & Thrash turn 1.       
 
 #### Oddish Girl
@@ -496,7 +496,6 @@ Walk into the bike shop, get the Bike, and exit the shop.
 After the fight:
 - Use a Repel around [this tile](gunnermaniac.com/pokeworld?map=232#32/16)
 - Use another Repel before the Hiker.
-	- If you were paralyzed, use a Parlyz Heal in one of the Repel Menus.
 	- You can Repel on different tiles if you prefer, we have a lot of extra steps.
 
 **Hiker:**
@@ -505,7 +504,10 @@ After the fight:
 **Jr Trainer F:**
 - Thrash
 
-Exit tunnel and get the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=21#16/53) in the bush to the right and bike straight down after hopping the ledge and avoiding the trainer's line of sight. 
+Exit tunnel and get the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=21#16/53) in the bush to the right.
+- Bike straight down after getting the item.
+- Hop the ledge and avoid the trainer's line of sight by biking behind them as you enter Lavender Town.
+- Immediately exit Lavender to the West.  
 
 ## Route 8
 
@@ -549,14 +551,14 @@ Exit tunnel and get the [hidden Max Ether](https://gunnermaniac.com/pokeworld?ma
 
 #### End of Shopping:
 - Take the elevator to 1F + exit the mart.
-- Bike West + cut the tree. 
+- Bike West + [cut the tree](https://www.extratricky.com/pokeworld/rb/1#144,125). 
 - Bike into the guard house and walk through it. 
-- Walk into the House and talk to the NPC.
-- Get HM02 (Fly) + exit the house.
+- Walk into the [Fly House](https://www.extratricky.com/pokeworld/rb/1#117,121) and talk to the NPC.
+- Get HM02 (Fly) + exit the Fly House.
 
 #### Fly Menu
 - Swap slot 2 Helix Fossil w/ TM07
-- d1 Use a Super Repel
+- d1 Use Super Repel
 - d3 Teach TM48 (Rock Slide) over Mega Punch (slot 1)
 - Swap slot 3 S.S. Ticket w/ X Accuracy
 - d3 Teach HM02 to Bird
@@ -594,7 +596,7 @@ Exit tunnel and get the [hidden Max Ether](https://gunnermaniac.com/pokeworld?ma
 - RS x2
 
 #### Get both Elixers
-- First is a [visible item ball here](http://gunnermaniac.com/pokeworld?map=145#12/10) and [the other is hidden here](http://gunnermaniac.com/pokeworld?map=146#4/12)
+- First is a [visible item ball here](http://gunnermaniac.com/pokeworld?map=145#12/10) and [the other is hidden here](http://gunnermaniac.com/pokeworld?map=146#4/12) on the next floor.
 - Take the heal pad
 
 **Channeler 2:**
@@ -616,7 +618,7 @@ Pick up the Rare Candy and walk down.
 - TB x3 (+ BB)
 
 **Rocket 2:**
-- X Accuracy + HD x2
+- **X Accuracy** + HD x2
 
 **Rocket 3:**
 - TB x2
@@ -635,9 +637,9 @@ Talk to Mr. Fuji twice to get the Poke Flute
 
 ## Saffron City
 
-- Bike into Silph Co. and take the stairs to Floor 5.
+- Bike into [Silph Co.](https://www.extratricky.com/pokeworld/rb/1#238,130) and take the stairs to Floor 5.
 - Get the [hidden tree Elixer](http://gunnermaniac.com/pokeworld?map=210#12/3)
-- <img src="https://pokemon-speedrunning.github.io/speedrun-routes/gen-1/images/classic/SilphCo1.png">
+- <img src="https://pokemon-speedrunning.github.io/speedrun-routes/gen-1/images/classic/SilphCo1.png" width="325">
 
 **Rocket w/ Arbok:**
 - Thrash x2-3
@@ -713,7 +715,8 @@ Dig out.
 - Teach TM26 (Earthquake) over Thrash (slot 2)
 - Use Bike
 
-> If zero potions left, then swap Helix Fossil with X Special instead. 
+> If zero potions left, then swap Helix Fossil with X Special instead.            
+> Only if zero potions, pick up an item in safari for bag space - such as this [Full Restore](https://www.extratricky.com/pokeworld/rb/217#21,10)            
 
 - Cut both trees to enter Safari Zone
 - <img src="https://pokemon-speedrunning.github.io/speedrun-routes/gen-1/images/classic/CutBothTrees.png" width="350">
@@ -751,7 +754,7 @@ In the Safari Zone:
      - (+ u2 X Special, if Koga uses X-Attack)
      - until Weezing uses Self Destruct
 
-> Do not revive Nido! Do not heal Nido!         
+> Do not revive/heal Nido!       
 > We have purposely allowed Nido to be KO'd (or hit to low health)           
 > so that we can use Rare Candies to bring Nido into red bar for the Gym Rush.          
 

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/lass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/lass/README.md
@@ -3,178 +3,282 @@
 **FAQ: [Please read the FAQ before learning :)](../../resources/faq.md)**
 
 ### Manip quick reference
+- Watch the [RBY Manip Guide](https://www.youtube.com/watch?v=QirPrbub21g)
 - Nidoran Manip:
-	- [Optimal](../../resources/nido-manip.md) (HIGHLY RECOMMENDED)
-	- [1 A Press](https://youtu.be/2bwQZ6jPxRE)
+	- [7A Press - Optimal](../../resources/nido-manip.md) (Highly recommended)
+	- [1A Press - Easy](https://youtu.be/2bwQZ6jPxRE)
 - Mount Moon Manip:
-	- [Post Hiker Backup Paras](https://pastebin.com/j5gtY4cy) (recommended for first runs)
-		- [Older version](https://pastebin.com/7kcZu3g4) (easier path, but select yoloball)
+	- [Post Hiker Backup Paras v1](https://pastebin.com/7kcZu3g4) ([2A Press Path](https://i.imgur.com/jp61CLR.png), [video w/ Select yoloball inputs](https://youtu.be/atQiH670ENs))
+	- [Post Hiker Backup Paras v2](https://pastebin.com/j5gtY4cy) (7A press, normal yoloball)
+	- Grogir's [Post Zubat Backup Paras](https://pastebin.com/5rKmACtf) 
 	- [Post Nerd Backup Paras](../../resources/postnerd-backup-paras.md)
-	- [Entr's Moon Manip](https://pastebin.com/jnj9j47S)
+	- [Entr's Full Moon Manip](https://pastebin.com/jnj9j47S) (Optimal for this route)
+       - [Route 3 Full Moon Manip](https://pastebin.com/tggXpQRC) (Route 3 does not work with this route due to fighting the Rt3 Lass, but is optimal for the main speedrun route)  
 - Surge Cans Manip:
-	- [Optimal](https://www.youtube.com/watch?v=8Pa2f2WxCe4)
+	- [Optimal Cans Manip](https://www.youtube.com/watch?v=8Pa2f2WxCe4)
+      - 58/60 success rate with 2A presses
+      - 57/60 success rate with zero A presses (same path, same cans)
+      - If this cans manip fails there is no need to resave, just hard reset and do the other version (it'll work because they don't share any failure frames).  
 	- [Palette Cans](https://youtu.be/_tWhfBITf_g) (allows you to see through Rock Tunnel by changing the palette)
-	- [60/60 Cans](https://www.youtube.com/watch?v=T6pXrZ9_Vq0) (slightly slower, but great success chance)
+	- [60/60 Cans](https://www.youtube.com/watch?v=T6pXrZ9_Vq0) (slightly slower + harder, but great success chance)
 
 ### Good documents
 - [Defensive Damage Ranges](../../resources/defensive-ranges.md)
 - [Offensive Damage Ranges](../../resources/offensive-ranges.md)
 - [Safety-oriented HP Strats](../../resources/hp-strats-for-races.md)
+- [Trainer Data Sheet](https://www.dropbox.com/scl/fi/an4xn77nxpyu1noz453nj/Pokemon-Red-trainer-guide.xlsx?rlkey=qi5v6pnrie4xy0e9hxjjiwkfj&e=1&dl=0)
 
 ### Glossary
-- Moves: HA = Horn Attack, MP = Mega Punch, BB = Bubblebeam, WG = Water Gun, TB = Thunderbolt, Blizz = Blizzard, PS = Poison Sting, HD = Horn Drill, RS = Rock Slide
+- Moves: TW = Tail Whip, HA = Horn Attack, PS = Poison Sting, WG = Water Gun, MP = Mega Punch, BB = Bubblebeam, TB = Thunderbolt, RS = Rock Slide, HD = Horn Drill, Blizz = Blizzard.
 	- (+ MOVE): A situational move used to finish off a pokemon when a damage range is missed
 - IT = Instant Text
 
+### Important Note
+- When learning a new move you cannot hit up to make the cursor wrap around to the bottom slot like you can in battle. For example, to teach over Slot 4, you must press down three times. Don't accidentally delete the wrong move.
+- Victory Road can be tricky. While there will be an image embedded showing the optimal strategy, we recommended watching this [easier version of Victory Road / Lorelei Segment Movement](https://youtu.be/AbekvWHeX50). In the description there are timestamps and a link to a video of the optimal movement (~5 seconds faster). 
+     - This guide assumes that you will use the optimal strategy in Victory Road, going slower/safer is optional. Note that the slower strategy still works if you accidentally wasted a Super Repel earlier, so it is worth knowing as a backup. 
+
 ### Before you start
 - Clear any existing save file by pressing Up + B + Select on the game title screen
-- Set your options to fast text and animations OFF
+- Options: Text Speed **Fast** and Animations **Off**
 
 ## Pallet Town
 
-- Name yourself and rival 'A'
-- Pick Squirtle and name it 'A'
+- Name yourself and rival 'A' (or any one-character name)
+- Pick Squirtle (middle ball) and name it 'A'
 
-**Rival 1:**
-- Tail Whip + spam Tackle
+#### Rival 1
+- TW + spam Tackle
+
+> **L6 Squirtle Stats**      
+> 10 ATK --> TW x3 on Weedle Guy     
+> 11 SPC --> likely bad Special for Brock      
+> No need to reset over bad Squirtle stats, just be aware of them.       
+
+## Parcel Quest
+
+> Go up Route 1 to get Oak's Parcel from Viridian Mart.    
+> Return to Oak's Lab, give him the Parcel, and get the Pokedex.     
+> Go back up Route 1 (back to the Viridian Mart).      
+
+KO **one** L2 or L3 encounter at some point during these trips up and down Route 1 by **spamming Tackle**
+- L2-3 Rat or L2 Pidgey are the easiest to KO without taking too much damage.
+- L3 Pidgey is okay too, but deals a lot of damage to us. For this reason, run away from L3 Pidgey on your first pass of Route 1 with the hopes of seeing a better encounter later.
+- Run from all L4-5 encounters and run from all encounters after you get EXP.
+- This early EXP will give Squirtle an extra level up at the end of Viridian Forest which gives us the move Bubble in time for Brock.
 
 ## Viridian City
 
-Get XP from one encounter in Route 1
-- During the parcel quest kill one encounter from a level 2 Rat, level 3 Rat, or a level 2 Pidgey. You can fight level 3 Pidgeys but you will take a bit of damage if you have a lower attack (10-11 at level 6) Squirtle. This early XP will get you Bubble for Brock
-
-Shopping:
-- 4 Poke Balls (This does require you to get consistent at manip yoloballs, you can buy 5 and 1 less Potion later on)
+Viridian Mart:
+- Buy **4 Poke Balls**
+     - (or buy 5 Poke Balls and buy 1 less Potion later)
 
 Nidoran Manip:
-- [Optimal (HIGHLY RECOMMENDED)](../../resources/nido-manip.md)
-- [1 A Press](https://youtu.be/qPzSWHyMuW8)
+- [7A Press - Optimal (Highly Recommended)](../../resources/nido-manip.md)
+- [1A Press - Easy](https://youtu.be/2bwQZ6jPxRE)
 
 Get the [hidden Tree Potion](https://gunnermaniac.com/pokeworld?map=1#54/166)
 
+<img src="https://i.imgur.com/H8JVzPL.png" height="100" >
+
 ## Viridian Forest
 
-- Walk [this path](http://gunnermaniac.com/pokeworld?map=51#17/47/UUUURURRRRRRRRUUUUUUUULUURRUUUUUUUUUUUULLUUUUUUUUAUUULLLLLLLLDDDDDDDLLLLUUUUUUUUUUUUULLLLLLDDDDDDDDDDDDDDDDDDDLLLLLLUUUA) in the forest and pick up the Antidote and the hidden Potion along the way
+- Walk the path below in the forest to decrease the chance of getting wild encounters.
+- Pick up the Antidote and the hidden Forest Potion (in front of Weedle Guy).
 
-**Weedle Guy:**
-- Tail Whip x2 + spam Tackle [1-6 Potion]
-- Check your leveled up stats after this fight, if you have 13 special you have bad special, if you have 14 or 15 you have good special
+<img src="https://i.imgur.com/9wWTgkB.png"> 
 
-If you were poisoned do the following:
-- Swap Nidoran and Squirtle (Nidoran should be the lead pokemon)
-- Antidote
-- 1-15 Potion
+> Note that only the tiles marked in red on the map can generate encounters. 
+
+**Weedle Guy:** [1-6 HP: Potion]
+- TW x2 + spam Tackle
+    - TW x3 if Bad ATK (10 ATK @L6)
+- Check your leveled up Special stat at the end of this fight (SPC is at the very bottom).
+    - 13 SPC @L8 --> Bad Special (likely to take 3 Bubbles instead of 2 to KO Brock's Pokemon)
+
+If you were poisoned, then menu immediately after the fight:
+- Swap Squirtle with Nidoran
+- Potion Squirtle to 16+ HP
+- Use the Antidote
+
+> If you were not poisoned, then delay this menu until one step into Brock's gym      
+> (saves time this way, but it's fine if you do it earlier).       
+> Note that swapping Nido to the lead is essential to swap-train Nido against Brock's Geodude & Onix.        
+> --> Nido will reach L8 and learn Horn Attack after Brock's Onix.   
 
 ## Pewter City
 
-Shopping:
-- 8 Potions
+Pewter Mart:
+- **Buy 8 Potions**
+     - (or buy 7 Potions if you bought 5 Poke Balls earlier)
 
-If you weren't poisoned do the following:
-- Swap Nidoran and Squirtle (Nidoran should be the lead pokemon)
-- 1-15 Potion and toss Antidote
-- [OPTIONAL SAVE IF YOU HAVE BAD SPECIAL]
+If you were not poisoned, then menu one step into Brock's Gym:
+- Swap Squirtle and Nidoran
+- Potion Squirtle to 16+ HP
+- Toss the Antidote
+- [Optional: Save before Brock if you have Bad Special (13 SPC @L8)]
 
-**Brock:**
-- Geodude [1-8 Potion]
-	- Swap to Squirtle, then spam Bubble
-- Onix [1-12 Potion]
-	- Swap to Squirtle
-		- IF ONIX USES BIDE: Tail Whip x2
-	- Spam Bubble
+#### Brock:
+- Geodude: [1-8 Potion]
+   - Swap to Squirtle + Bubble x2-3
+        - Say Yes + swap back to Nido
+- Onix: [1-12 Potion, 1-14 after Screech]
+	 - Swap back to Squirtle + Bubble x2-3
+        - TURN 1 BIDE --> TW x2
+        - If you Bubble after BIDE, keep using Bubble (do not Potion - due to a gen 1 bug, using Potion after a damaging move will cause Bide to KO)
 
-Options: Battle Style to Set before leaving Brock's gym
+**Options**: Battle Style to **Set** before leaving Brock's gym
 
 ## Route 3
 
-**Bug Catcher 1:**
-- Caterpie: Leer + HA x2 (+ Tackle)
-- Weedle: Leer + HA x2
-	- Leer + HA + Tackle if you got String Shot hit OR Tackle will always kill
-- Caterpie: HA x2 + Tackle
+<img src="https://i.imgur.com/0lfYzCR.png">
 
-Menu:
-- Potion to 28+
+**Bug Catcher 1:**
+- Caterpie:
+    - Leer + HA x2 (+ Tackle)
+- Weedle: [1-9 Potion]
+    - Leer + HA x2
+    - (Tackle turn 3 if you hit by String Shot)
+- Caterpie:
+    - Leer + Tackle + HA (+ Tackle)
+
+#### Menu before Shorts Guy:
+- Potion to 28+ HP
 - Toss Antidote if you still have it
 
 **Shorts Guy:**
-- Rat: [1-15 Potion]
+- Rat: [1-15 Potion, 1-18 if @-2 DEF]
 	- Leer + HA x2
-- Ekans: [1-4 Potion, or 1-5 at -2 defense]
+- Ekans: [1-5 Potion, 1-6 if @-2, 1-8 if @-3]
 	- Leer + HA x2
-		- Potion turn 1 of Wrap if you don't live 4 or 5 turn Wrap
+		- In general, **Potion** immediately after turn 1 of **Wrap** hit.
+    - Since Wrap lasts 2-5 turns, we avoid chain wrap by using the Potion right away.    
 
-**Bug Catcher 2:**
-- Weedle:
+#### Bug Catcher 2
+- **Weedle**:
 	- HA x2
-- Kakuna:
-	- Spam HA, finish with Tackle
-- Caterpie: [1-5 Potion]
-	- HA x2
-- Metapod:
-	- HA x2 + Tackle
+- **Kakuna**:
+	- HAx3 (+ Tackle)
+- **Caterpie**: [1-5 Potion]
+    - HA x2 (only Tackle turn 2 if hit by 2+ stringshots before 1st HA hits or if HA crits)
+- **Metapod**:
+	- HA x2 + Tackle (only HA turn 3 if you were slower than Metapod due to 2-3+ string shots)
 
-Menu: Potion to 22+
+#### Menu
+- Potion to 22+ HP
 
-**Lass:** (this route also fights the optional lass)
-- HA x4
+#### Lass
+- Rat: HA x2
+- NidoranM: HA x2
 
-**Bug Catcher 3:**
+> Save at least 1 HA for after BC3       
+> Spam PS if only 1 HA is left       
+
+#### Bug Catcher 3
 - Caterpie:
-	- PS x2 (HA turn 2 if PS won't kill and you didn't get turn 1 String Shot hit)
+    - PS x2 (HA turn 2 instead if low roll + not hit by String Shot)
 - Metapod:
-	- HA, PS, HA, PS (you really want at least 1 HA after this fight, if you are at 1 HA just PS)
+    - HA, PS, HA, PS 
 
-Route 3 grass:
-- Catch a flyer
-	- Tackle then toss a Ball at any flyer except L8 Pidgey where you HA then toss a Ball
-- Kill one encounter in the grass with HA except level 3 or level 7 Jigglypuffs to get Nidoran to level 15
+#### Catch a flyer & KO one Encounter
+- **L8 Pidgey**:
+     - **HA** if you have one (otherwise: Leer + Tackle), then throw balls
+- **any other Bird**:
+     - **Tackle**, then throw balls
+- KO one encounter in the grass with HA (except L3 or L7 Jigglypuffs)
+     - This EXP will let Nido reach L15
 
 ## Mount Moon
 
-- Do not learn a full Moon Manip for your first runs, start by learning [Post Hiker Backup Paras](https://pastebin.com/j5gtY4cy) (or the [older version](https://pastebin.com/7kcZu3g4)) and walk through the first floor normally ([movement map](https://i.imgur.com/xzgmNBk.jpeg)). You will choose later if you want to learn [Entr Moon](https://pastebin.com/jnj9j47S) (works with Lass) or [Route 3 Moon](https://pastebin.com/tggXpQRC) (slightly better, but does not work with Lass strats). There is also a [Post Nerd Backup Paras](../../resources/postnerd-backup-paras.md) you can learn.
-- Get [TM12 (Water Gun)](https://gunnermaniac.com/pokeworld?map=59#5/32), [Rare Candy](https://gunnermaniac.com/pokeworld?map=59#35/31), [Escape Rope](https://gunnermaniac.com/pokeworld?map=59#36/23), [TM01 (Mega Punch)](https://gunnermaniac.com/pokeworld?map=61#29/5) and [Moon Stone](https://gunnermaniac.com/pokeworld?map=59#2/2)
-- Avoid catching wild Paras as the catch is not guaranteed even at low HP, catch the manipped one instead
+> If you are not attempting a full moon manip for now,      
+> then follow this [movement map](https://i.imgur.com/xzgmNBk.jpeg) to make it to the backup paras manip below,       
+> run from any random encounters.       
 
-Menu before walking in front of the Rocket:
+#### Enter Mt. Moon and open the Menu immediately
+- Potion to 22+ HP
+
+#### Save & Do [Entr's Full Moon Manip](https://pastebin.com/jnj9j47S)
+- **Hold A on the Bios Screen** immediately after Hard Reset, Select Yoloball (or Normal Yoloball if in redbar)
+- Get [TM12 (Water Gun)](https://gunnermaniac.com/pokeworld?map=59#5/32), [Rare Candy](https://gunnermaniac.com/pokeworld?map=59#35/31), [Escape Rope](https://gunnermaniac.com/pokeworld?map=59#36/23), [TM01 (Mega Punch)](https://gunnermaniac.com/pokeworld?map=61#29/5) and [Moon Stone](https://gunnermaniac.com/pokeworld?map=59#2/2)
+- Performing a full Moon Manip is not required when starting out, but it doesn't hurt to attempt it and see how far you get.
+- If you fail the manip at some point (or get an IGT failure), then just run from the extra encounters until you get to one of the backup manip locations below.
+- Avoid trying to catch a random wild Paras since the catch is not guaranteed even at low HP, catch a manipped one instead.
+
+#### _PoY's [Post Hiker Backup Paras v1](https://pastebin.com/7kcZu3g4)
+- If Entr's Moon Manip has failed, then save immediately after going through the ladder after Moon Stone
+- 2A Presses, [Select Yoloball - click here for a video of the inputs](https://youtu.be/atQiH670ENs)
+- <img src="https://i.imgur.com/2OPBuoM.png" width = "200"> <img src="https://i.imgur.com/Z7KX0B8.png" width = "250">
+
+#### Grogir's [Post Zubat Backup Paras](https://pastebin.com/5rKmACtf) 
+- **Hold A on the Bios Screen** immediately after Hard Reset
+- Normal yoloball
+- <img src="https://i.imgur.com/dk5eT3x.png" width = "300">
+
+#### Menu before walking in front of the Rocket:
 - Toss any remaining Poke Balls (ONLY IF YOU HAVE A PARAS)
 - Use Rare Candy
 - Teach TM12 (Water Gun) over Tackle (slot 2)
 - Use Moon Stone
 - Teach TM01 (Mega Punch) over Leer (slot 1)
 
-**Rocket:**
-- Rat: MP
-- Zubat: MP + PS (HA if Zubat used Leech Life, MP if Leech Life also crit)
+#### Moon Rocket (HA Count Remaining --> Strategy):
+- Rattata
+     - MP
+- Zubat
+     - MP + PS (HA or MP if hit by Leech Life)
 
-Talk to the Nerd
+#### Moon Rocket's Zubat (When to Potion)
+| DEF  | Not confused  | Confused      |
+| ---- | ------------- | ------------- |
+| -0   |      1-8      |     1-18      |
+| -1   |      1-8      |     1-22      |
+| -2   |      1-9      |     1-32      |
 
-**Super Nerd:** (if you are out of HA just MP instead)
-- Grimer: MP + HA [Note: Water Gun can kill if you get a good MP roll, if so use WG over MP or HA]
-- Voltorb: MP + PS
-- Koffing: HA + MP if you have an HA, otherwise MP x2
+Walk UP and talk to the Super Nerd from below.
+
+**Super Nerd**:
+- Grimer: (HA or MP turn 2 if turn 1 is a low roll)
+	- MP + WG 
+- Voltorb:
+	- MP + PS
+- Koffing: (WG turn 2 if turn 1 is a crit)
+	- HA + MP or MP x2 
 
 If you still need Paras: [Post Nerd Backup Paras](../../resources/postnerd-backup-paras.md)
+- Hold a palette selection through bios immediately after Hard Reset
+- 2A Presses
+
+<img src="https://i.imgur.com/rRnoayt.png" width="225"> <img src="https://i.imgur.com/MFBagiA.png" width="125">
 
 ## Nugget Bridge
 
-- Use the center
+- Use the Pokemon Center in Cerulean City.
 - Get IT (Instant Text)
-	- You talk to the bike salesman and mash B through his text, this will set all text to instant. Things that kill instant text are Yes/No textboxes, opening the menu in and out of fights.
+     - Talk to the bike salesman and mash B through his text, this will set all text to instant.
+     - IT is lost any time you get a Yes/No textbox or anytime you open the menu either in or out of fight.
+     - During first runs especially, it's okay to lose IT at some point in order to play safely. 
 - Pick up the [hidden Rare Candy](http://gunnermaniac.com/pokeworld?map=1#235/44)
 
-**Bridge Rival:**
-- Pidgeotto: HA x3 (if you get some bad rolls use MP to kill)
-	- If you get hit by 2 Sand-Attacks swap to your bird and let it die
-		- Try to put Pidgeotto in HA range before doing this to avoid getting Sand-Attacked again after swapping back
-		- Get IT again after the fight
-- Abra: HA
-- Rat: MP
-- Bulba: MP + HA (MP if you get Growled or miss a bunch into Leech Seed healing)
+#### Bridge Rival:
+- Pidgeotto
+    - HA x3 (MP turn 3 if bad HA rolls)
+	  - If you get hit by 2 Sand-Attacks swap to your bird and let it be KO'd
+          - Try to put Pidgeotto in HA range before doing this to avoid getting Sand-Attacked again
+          - Swap --> return to the Bike Shop after Rival, Potion (if needed), and reget IT
+- Abra
+     - HA
+- Rat
+     - MP (or HA if hit by TW x2)
+- Bulba
+     - MP + HA (or MP turn 2 if hit by Growl)
+
+> If under ~20 HP after Boat Rival, then either         
+> (1) use a Potion (if you have at least 3 left) and go back to get IT again       
+> (2) use the Center again and go back to get IT again       
 
 **BC:**
 - MP (+ PS)
-- MP (if you missed MP into String Shot hit use HA)
+- MP (HA if hit by String Shot)
 
 **Lass:**
 - MP (+ PS)
@@ -189,14 +293,17 @@ If you still need Paras: [Post Nerd Backup Paras](../../resources/postnerd-backu
 - MP (+ PS)
 - HA x2
 
-**Mankey:** [Note: Mankey is 1/3 to Karate Chop and does 12-15, healing is an option but is slow because you lose IT]
-- 1-7 MP (+ PS)
-- 8-27 HA x2 [Note: PS can kill if you get a good HA roll, if so use PS over the second HA]
-- 28+ MP (+ PS)
+> 1-7 HP: Potion before the next fight (do not go back for IT, it's too far away now)      
+> Note: Mankey is 1/3 to Karate Chop and typically does 12-14 dmg, so healing is recommended
+
+**Mankey:**
+- 8-14: Potion turn 1 (or HA + HA/PS to yolo)
+- 15-27: HA + HA/PS
+- 28+: MP (+ PS)
 
 **Rocket:**
-- Ekans: MP
-- Zubat: HA
+- MP
+- HA
 
 ## Route 25
 
@@ -207,15 +314,19 @@ If you still need Paras: [Post Nerd Backup Paras](../../resources/postnerd-backu
 - MP
 - HA x2
 
+> 1-7 HP: Potion before the Hiker
+
 **Hiker:**
 - WG
 - WG
 - MP (+ PS)
 - WG
 
+> 1-6 HP: Potion turn 1 on Lass' 1st Oddish
+
 **Lass:**
 - MP
-	- Teach Thrash over Water Gun (slot 2)
+     - Teach Thrash over Water Gun
 - Thrash
 
 Menu after Bill:
@@ -224,22 +335,31 @@ Menu after Bill:
 
 ## Cerulean City
 
-- Use the center
+- **Use the Pokemon Center**
 - Get IT again
 
 **Dig Rocket:**
-- Thrash
+- Thrash x1-2
+- Thrash x1-2 (+PS)
+
+> Important Note: after defeating Misty she gives us TM11 (Bubblebeam)        
+> TM11 will be taught over Slot 4 Poison Sting at some point before Surge      
+> Remember that when teaching moves you can NOT wrap around to slot 4 like you can when using moves in fight.      
+> Remember to hit Down x3 when teaching over a move like Poison Sting in Slot 4 to avoid overwriting the wrong move       
+
+Enter Misty's Gym + avoid the swimmer by going Up then Left + around.
 
 **Jr Trainer F:**
-- Thrash
+- Thrash x2
 
-**Misty:**
-- Thrash
-	- If you are ever alive and confused swap to another poke (bird) and let it die
+#### Misty:
+- Thrash x1
+- Thrash x2-3
+	- If confused on Starmie, swap to bird and let it be KO'd.
 
 If 1-15 after Misty (or 16-24 and you want to play safely):
-- Potion
-- Teach TM11 (Bubblebeam) over PS (slot 4)
+- Potion (or use the center again to avoid using your last potion)
+- Teach TM11 (Bubblebeam) over PS (slot 4 - D3)
 - Get IT again
 
 ## Vermilion City
@@ -250,76 +370,102 @@ If 1-15 after Misty (or 16-24 and you want to play safely):
 **Jr Trainer M:**
 - Thrash
 
-If 1-12 after this fight:
+If 1-12 after this fight (or 13-22 to be extra safe):
 - Potion
-- Teach TM11 (Bubblebeam) over PS (slot 4)
+- Teach TM11 (Bubblebeam) over PS (slot 4 - D3)
 
-**Boat Rival:**
-- Pidgeotto:
+#### Boat Rival
+- Pidgeotto
 	- HA x2 (HA + BB if taught; Potion turn 2 if 1-6)
-	- If you get Sand-Attacked swap to another pokemon and let it die
-- Rat:
+	- If you get Sand-Attacked swap to Bird or Squirtle and let them be KO'd
+- Raticate
 	- 1-6 Potion
-	- 7-22 MP [Note: Potion on 7-12 is extra safe]
+	- 7-22 MP [Note: can Potion on 7-12 (or 13-22) to be extra safe against Hyper Fang]
 	- 23+ HA + PS or BB x2
-- Kadabra:
+- Kadabra
 	- 1-6 HA Kadabra & Potion turn 1 on Ivysaur, then Thrash
-	- 7+ Thrash Kadabra
+	- 7-12 Thrash Kadabra (or HA Kadabra + Pot on Ivy to be extra safe)
+  - 13+ Thrash Kadabra
+- Ivysaur
+  - Thrash x2 
 
 Talk to the Captain to get HM01
 
-Depending of your HP, you may fight the Gentleman in [this room](https://gunnermaniac.com/pokeworld?map=96#21/11) with Thrash then pick up the Rare Candy
+Depending of your HP, you may fight the Gentleman in [the 3rd Cabin from the Right](https://gunnermaniac.com/pokeworld?map=96#21/11) with Thrash then pick up the Rare Candy.
 
-| HP    | Strategy                                |
-| ----- | --------------------------------------- |
-| 1     | Skip Gentleman, use Potion in Cut Menu  |
-| 2-8   | Do Gentleman                            |
-| 9-24  | Do Gentleman if you want to play safely |
+| HP     | Strategy                                              |
+| ------ | ----------------------------------------------------- |
+| 1      | Do Gentleman + use a Potion at the start of Cut Menu  |
+| 2-14   | Do Gentleman                                          |
+| 15-24  | Do Gentleman if you want to play extra safely         |
 
-> Important note for shopping: **always buy items in the order that they are listed in this guide**. Doing so is both the fastest way to buy the items and sets up our inventory in the correct order.  
+> Important note for shopping: **always buy items in the order that they are listed in this guide**.       
+> Doing so is both the fastest way to buy the items and sets up our inventory in the correct order.        
 
-Shopping:
-- Buy:
-	- 6 Repels
-	- 4 Parlyz Heals
+#### Vermillion Mart:
+- 6 Repel
+- 4 Parlyz Heal
 
-Menu before Cut bush:
-- Teach TM11 (Bubblebeam) over PS (slot 4)
+> Walk to the tree guarding Surge's Gym
+
+#### Cut Menu:
+- Teach TM11 (Bubblebeam) over PS (slot 4 - D3)
 - [Rare Candy if you fought the Gentleman]
 - Teach HM01 to Paras
 - Teach TM28 (Dig) to Paras
 - Use Cut
 
-Surge Cans Manip:
-- [Optimal](https://www.youtube.com/watch?v=8Pa2f2WxCe4)
-- [Palette Cans](https://youtu.be/_tWhfBITf_g) (allows you to see through Rock Tunnel by changing the palette)
-- [60/60 Cans](https://www.youtube.com/watch?v=T6pXrZ9_Vq0) (slightly slower, but great success chance)
+#### Surge Cans Manip:
+- [Optimal Cans](https://www.youtube.com/watch?v=8Pa2f2WxCe4)
+     - 57/60 success rate w/ zero A pressses
+     - 58/60 success rate w/ the two A presses outside
+- [Palette Cans](https://youtu.be/_tWhfBITf_g)
+     - 59/60 success rate + allows you to see through Rock Tunnel by changing the palette with an Up+B tap.
+- [60/60 Cans](https://www.youtube.com/watch?v=T6pXrZ9_Vq0)
+     - slightly slower and less beginner friendly due to a start flash and 3 A presses
 
 **Surge**
 - Voltorb:
 	- 1-24 Thrash
-	- 25+ BB + HA
+	- 25+ BB x2
 - Pikachu:
 	- Thrash
 - Raichu:
-	- If you are confused and dead to a self hit, swap to your bird or Squirtle
+	- Thrash x2
+        - If you are confused and dead to a self hit, swap to sac your bird or Squirtle
 
-Get the Bike Voucher and use Dig on Paras
+</td><td>
 
-## Cerulean City
+Surge's Raichu    | Hit Self | w/gentleman candy 
+----------------- | -------- | -----------------
+&nbsp;            | **14**   | 15
+w/Growl           | **9**    | 10
+w/Screech         | **29**   | 31
+w/Screech & Growl | **17**   | 18
 
-- Get the Bike
-- Menu:
-	- Swap (using select) slot 1 with the Bike
-	- Teach TM24 (Thunderbolt) over HA (slot 3)
-	- Use the Bike
+Exit the gym, get the Bike Voucher from the guy in the Fan Club, and then use Dig.
+
+## Warp back to Cerulean City
+
+> Note: items are swapped around using the Select button       
+> Bike Menu below is the first instance of an item swap in this guide       
+
+Walk into the bike shop, get the Bike, and exit the shop.
+
+#### Bike Menu:
+- Swap slot 1 Potion w/ Bike
+- Teach TM24 (TB) over Horn Attack (slot 3)
+- Bike + cut both trees (see below)
+
+<img src="https://pokemon-speedrunning.github.io/speedrun-routes/gen-1/images/classic/Bike4TTG.png">
 
 ## Route 9
 
-**4 Turn Thrash Girl:**
-- MP
-- Thrash
-	- If you run out of MP just Thrash, you will be 25% to hit yourself on the last poke
+#### 4 Turn Thrash Girl:
+- MP (Thrash if 0 MP are left)
+- Thrash x3
+     - if confused, typically just use Thrash to yolo 
+     - if confused + fought the Gentleman on boat, then you can swap + swap back to split exp with another poke
 
 **Bug Catcher:**
 - BB (Thrash if you fought the Gentleman)
@@ -327,32 +473,31 @@ Get the Bike Voucher and use Dig on Paras
 
 ## Rock Tunnel
 
-[Map of both floors](https://imgur.com/gallery/uoueIjq)
+<img src="https://i.imgur.com/gs5N4V5.png">
 
-Menu after taking 1 step down:
-- Scroll down and use a Repel
+> Quick Reference     
+> Slot 7: Repel      
+> Slot 8: Parlyz Heal     
+> Slot 9: Potion      
 
-**Pokemaniac 1:**
-- BB
-- TB
+- **Pokemaniac 1**: BB, TB
+- **Pokemaniac 2**: TB
 
-**Pokemaniac 2:**
-- TB
+> Save before Oddish Girl if **under 43 HP**.      
+> Gentleman --> Always skip save & Thrash turn 1.       
 
-[Optional Save if 1-17 and you did not fight the Gentleman]
-
-**Oddish Girl:**
-- If you fought the Gentleman, Thrash. The ranges are guaranteed
-- 18-22 TB, then Thrash
-- Otherwise, just Thrash
-	- If you get put to sleep, Potion at 1-5
-	- If paralyzed, keep using Thrash
+#### Oddish Girl
+- 1-17 or 23+ HP ---> **Thrash turn 1**
+- 18-22 HP ---> **TB + Thrash**
+     - Sleep ---> 1-13 HP: Potion
+     - Para'd ---> keep Thrashing, but 1-14 HP: Potion
+     - Do not Para Heal in fight, use it in the next Repel Menu instead.
 
 After the fight:
-- Use one Repel [here](https://gunnermaniac.com/pokeworld?map=232#25/19)
-- Use another Repel [here](https://gunnermaniac.com/pokeworld?map=232#8/17)
-	- If you were paralyzed, use a Parlyz Heal now
-	- You can delay these 2 Repels up to ~10 tiles
+- Use a Repel around [this tile](gunnermaniac.com/pokeworld?map=232#32/16)
+- Use another Repel before the Hiker.
+	- If you were paralyzed, use a Parlyz Heal in one of the Repel Menus.
+	- You can Repel on different tiles if you prefer, we have a lot of extra steps.
 
 **Hiker:**
 - BB x3
@@ -360,69 +505,97 @@ After the fight:
 **Jr Trainer F:**
 - Thrash
 
-Get the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=21#16/53)
+Exit tunnel and get the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=21#16/53) in the bush to the right and bike straight down after hopping the ledge and avoiding the trainer's line of sight. 
 
 ## Route 8
 
-**Gambler:**
+#### Gambler:
 - Growlithe:
 	- 1-8 Potion
 	- BB
 - Vulpix: Thrash
 
+> Carefully [avoid optional trainers](https://i.imgur.com/3TbEDS8.png) and enter the underground. 
+
 ## Underground
 
+- Take the stairs down + get on the Bike.
 - Get the [hidden Elixer](http://gunnermaniac.com/pokeworld?map=121#21/5)
 - Get the [hidden Nugget](http://gunnermaniac.com/pokeworld?map=121#12/2)
+- Exit the underground + get back on the Bike. 
 
 ## Celadon City
 
-Shopping:
+> If you fought the Gentleman on the boat, you can buy +1 X Accuracy. 
+
+#### Celadon Mart:
 - Floor 2:
 	- Sell TM34
 	- Sell both Nuggets
 	- Buy TM07
-	- Buy 7 Super Repels
-	- Buy 4 Super Potions
-	- Buy 2 Revives
+	- Buy 7 Super Repel
+	- Buy 4 Super Potion
+	- Buy 2 Revive
 - Floor 4:
-	- Buy Poke Doll
+	- Buy 1 Poke Doll
 - Roof:
-	- Buy a Soda Pop and trade it to the girl
-	- Come back and buy a Fresh Water
+	- Buy a **Soda Pop**
+             - trade it to the girl for TM48 (RS)
+	- Walk back to the vending machine and buy a **Fresh Water**
 - Floor 5:
-	- Buy 12 X Accs
-	- Buy 9 X Specs (7 if you have 0 Potions at this point)
-	- Buy 1 X Speeds (3 if you have 0 Potions at this point)
+	- Buy 12 X Accuracy
+	- Buy 9 X Special
+	- Buy 1 X Speed
 
-Take the elevator and get HM02 (Fly)
+#### End of Shopping:
+- Take the elevator to 1F + exit the mart.
+- Bike West + cut the tree. 
+- Bike into the guard house and walk through it. 
+- Walk into the House and talk to the NPC.
+- Get HM02 (Fly) + exit the house.
 
-Menu after getting Fly:
-- Swap slot 2 with TM07
-- Use a Super Repel
-- Teach TM48 (Rock Slide) over Mega Punch (slot 1)
-- Swap slot 3 with X Accs
-- Teach HM02 to the bird
-- Use Fly to go to Lavender
+#### Fly Menu
+- Swap slot 2 Helix Fossil w/ TM07
+- d1 Use a Super Repel
+- d3 Teach TM48 (Rock Slide) over Mega Punch (slot 1)
+- Swap slot 3 S.S. Ticket w/ X Accuracy
+- d3 Teach HM02 to Bird
+- Fly (D3) to Lavender Town
+     - Walk East into the tower.
 
-## Lavender Town
+## Lavender Tower
 
-Note: From this point on you have 2 Revives which means deaths aren't as scary, so if you die remember to swap to a pokemon, Revive, let the swapped pokemon die and ANY AND ALL X ITEMS ARE GONE. This route has extras so you shouldn't run out of X items, and there will still be some saving since some deaths with Revives are still really slow to come back from if at all.
+- [Click here for Lavender Tower Movement Maps](https://imgur.com/a/J5e6jKB)
 
-**Rival:**
-- Pidgeotto:
-	- 1-8 Potion (X Acc if you get Sand-Attacked)
-	- TB
-- TB
-- BB
-- Thrash
+> You now have 2 Revives which means you can recover if Nido is KO'd.      
+> In general, if Nido is KO'd, then (1) swap to another pokemon, (2) use a revive on Nido       
+> (which leaves the cursor on Nido now!), (3) let the swapped pokemon be KO'd, and (4) send Nido back in.         
+> This route has extra X items so remember to re-use any required X items after reviving (if applicable)        
 
-[Tower Movement Map](https://imgur.com/gallery/Yf2tY3u)
+#### Lavender Rival:
+- Pidgeotto
+     - 1-8 HP: 
+          - Potion (or Super Potion to avoid using your last Potion)
+          - (+ X Accuracy, if hit by Sand Attack)
+          - TB
+     - 9+ HP: 
+          - TB
+- Gyarados
+     - TB
+- Growlithe
+     - (Potion or Super Potion if under 9 HP)
+     - BB
+- Kadabra
+     - Thrash x1
+- Ivysaur
+     - Thrash x2
 
 **Channeler 1:**
 - RS x2
 
-- Get the Elixers [here](http://gunnermaniac.com/pokeworld?map=145#12/10) and [here](http://gunnermaniac.com/pokeworld?map=146#4/12)
+#### Get both Elixers
+- First is a [visible item ball here](http://gunnermaniac.com/pokeworld?map=145#12/10) and [the other is hidden here](http://gunnermaniac.com/pokeworld?map=146#4/12)
+- Take the heal pad
 
 **Channeler 2:**
 - RS
@@ -430,294 +603,478 @@ Note: From this point on you have 2 Revives which means deaths aren't as scary, 
 **Channeler 3:**
 - RS
 
+Pick up the Rare Candy and walk down. 
 
-- Pick up the Rare Candy in your way
+#### Menu (a few tiles below picking up the candy):
 - Teach TM07 (Horn Drill) over Rock Slide (slot 1)
 
-**Ghost Encounter:**
-- Swap slot 3 with Super Repels
-- Use Poke Doll
+**Marowak Ghost Encounter:**
+- Swap slot 3 HM01 w/ Super Repel
+- d3 use Poke Doll
 
 **Rocket 1:**
 - TB x3 (+ BB)
 
 **Rocket 2:**
-- X Acc + HD x2
+- X Accuracy + HD x2
 
 **Rocket 3:**
 - TB x2
-- Thrash
+- Thrash x2-3
 
-Get the Poke Flute and Fly to Celadon City
+Talk to Mr. Fuji twice to get the Poke Flute
+- Exit the house and Fly (D1) to Celadon
 
 ## Celadon City
 
-- Use the center
-- Bike to Saffron City
+- **Use the Celadon Pokemon Center**
+     - ^this is essential to replenish PP + set our warp point. 
+- Exit the center and Bike East to Saffron City
+     - The guard will take your Fresh Water.
+- Enter Saffron City + get back on the bike. 
 
 ## Saffron City
 
-- Enter Silph Co and take the stairs to floor 5
-- Get the [hidden Elixer](http://gunnermaniac.com/pokeworld?map=210#12/3)
+- Bike into Silph Co. and take the stairs to Floor 5.
+- Get the [hidden tree Elixer](http://gunnermaniac.com/pokeworld?map=210#12/3)
+- <img src="https://pokemon-speedrunning.github.io/speedrun-routes/gen-1/images/classic/SilphCo1.png">
 
-**Rocket 1:**
-- Thrash
+**Rocket w/ Arbok:**
+- Thrash x2-3
+     - If paralyzed, just keep thrashing. 
 
-Get the Card Key
+> If under 90 HP + Paralyzed, then menu to use Parlyz Heal now.     
+> Otherwise, delay using a Parlyz Heal until you are in the next fight.     
 
-**Rival:**
-- Pidgeot:
-	- X Acc
-	- If you were paralyzed on Arbok, use a Parlyz Heal
-	- X Speed
-- HD x5
+Take the teleporter twice, get the Card Key, take the teleporter twice again. 
+- Open the door on the left and take the teleporter. 
+- Walk right + open the middle left door. 
+- Take the teleporter + walk Up + Left to have Silph Rival walk up to you.
+     - This results in fewer steps overall since rival exits screen quicker after the fight this way. 
 
-Note: In this split we want to take a bit of damage to do a strat on Koga called Boom Strats
+#### Silph Rival:
+- Pidgeot
+	- **X Accuracy**
+	- (+ Parlyz Heal, if needed) 
+	- **X Speed**
+        - HD x5
 
-If 1-77, use an Elixer before the next fight
+> Note: In this split we want to take a bit of damage to do a strat on Koga that we call "Boom Strats".        
+> Boom Strats --> intentionally being KO'd by Koga's Weezing (from Selfdestruct) to set up late-game red bar.       
 
-**Rocket 2:**
-- Cubone:
-	- X Acc
-	- If Cubone damages you below 78 and you haven't used Elixer, use it now
-	- BB
-- Drowzee:
-	- If you haven't used Elixer, use it now
-	- HD
-- Marowak: HD
+#### When to use Silph Elixer:
+- If under 78 HP, then menu after taking the teleporter pad + use Slot 8 **Elixer** before the next fight. 
+- If 78+ HP, then we delay using the Elixer - follow the Silph Rocket fight notes below. 
 
-**Giovanni:**
-- X Acc + HD
-- HD
-- BB
-- HD
+#### Silph Rocket:
+- Cubone
+	- **X Accuracy**
+	- if Bone Club hits, then use **Elixer** now (if you haven't already)
+	- **BB**
+- Drowzee
+	- If you haven't used **Elixer** yet, use it now.
+	- **HD**
+- Marowak
+        - **HD**
 
-Go back to the elevator and go to the 10th Floor to get [TM26 (Earthquake)](https://gunnermaniac.com/pokeworld?map=234#2/12) and the [Rare Candy](https://gunnermaniac.com/pokeworld?map=234#4/14)
+#### Silph Giovanni:
+- Nidorino: **X Accuracy** + HD
+- Kangaskhan: HD
+- Rhyhorn: **BB**
+- Nidoqueen: HD
 
-Use Dig on Paras
+Go back to the elevator and go to the 10th Floor to get [TM26 (Earthquake)](https://gunnermaniac.com/pokeworld?map=234#2/12) and a [Rare Candy](https://gunnermaniac.com/pokeworld?map=234#4/14)
+
+Dig out.
 
 ## Celadon City
 
-- Use your Bike and go to Snorlax
+- Bike west to Snorlax
 
-Menu before Snorlax:
-- Use a Repel
-- Swap slot 5 (Parlyz Heal) for Rare Candies
-- Use Poke Flute
+#### Snorlax Menu
+- Slot 4 - Repel
+- d1 swap Parlyz Heal w/ Rare Candy
+- d1 use Poke Flute
 
 ## Cycling Road
 
-- Note: You can hold B to stop automatically moving down on Cycling Road
+- Note: You can hold B (or A) to stop on Cycling Road (otherwise you move down automatically)
 - Get the [hidden Rare Candy](http://gunnermaniac.com/pokeworld?map=1#125/148)
+- <img src="https://pokemon-speedrunning.github.io/speedrun-routes/gen-1/images/classic/CyclingRoad.png" width="300">
+
 
 ## Fuschia City
 
-Menu:
-- Use a Repel
-- Swap slot 6 (Potion) with X Spec (if 0 Potions, then swap Helix Fossil with X Spec instead)
+- Exit Cycling Road, walk through the guard house, and menu when you exit.
+
+#### EQ Menu:
+- Slot 4 - Repel
+- d2 swap Potion w/ X Special
 - Teach TM26 (Earthquake) over Thrash (slot 2)
 - Use Bike
+
+> If zero potions left, then swap Helix Fossil with X Special instead. 
+
+- Cut both trees to enter Safari Zone
+- <img src="https://pokemon-speedrunning.github.io/speedrun-routes/gen-1/images/classic/CutBothTrees.png" width="350">
 
 [Safari Movement Map](https://imgur.com/gallery/h9KpU3I)
 
 In the Safari Zone:
-- Super Repel on the 2nd map around [this tile](https://gunnermaniac.com/pokeworld?map=217#13/24)
-- Pick up the [Teeth](https://gunnermaniac.com/pokeworld?map=219#19/7) and get Surf
-- After getting Surf, Dig out of the safari and Fly back to Fuschia City
+- Super Repel in Zone 2 around [this tile](https://gunnermaniac.com/pokeworld?map=217#13/24)
+- Pick up the [Gold Teeth](https://gunnermaniac.com/pokeworld?map=219#19/7)
+- Enter the Surf House and get HM03 (Surf)
+- Exit the Surf House
 
-**Juggler 1:**
+#### Menu (after exiting the house):
+- Use Dig
+- Fly (D2) back to Fuschia City
+- Walk West and enter Koga's Gym
+- <img src="https://i.imgur.com/pN22DR8.png" width="125">
+
+#### Juggler 1:
 - EQ x4
 
-**Juggler 2:**
+#### Juggler 2:
 - EQ
 - EQ + TB
-	- If TB gets disabled, finish with BB if it's in range, finish with EQ if not or you don't know the range
+     - If TB gets disabled, finish with BB if it's in range, finish with EQ if not or you don't know the range
 
-**Koga:**
+> Ideally we either get KO'd by Weezing's Selfdestruct or hit below 15 HP, in which case, play normally.      
+> If you lived with 15+ HP, still play normally for now...      
+> ... but note that there will be a simple backup strategy to stall on Erika for damage later.      
+
+#### Koga:
 - EQ x3
-- Elixer on Weezing
-	- If Koga used X Attack, scroll up 2 and use X Spec until you die
-	- If you didn't die from Koga you can still try to get red bar by following the [intermediate backups](https://docs.google.com/document/d/1_q5ddsyYnIKN48_UlokZw4mPmlMZLnTXDPihN_UQFwY/edit?usp=sharing). Note that this can be risky
+- Weezing: 
+     - Use Slot 8 **Elixer** 
+     - (+ u2 X Special, if Koga uses X-Attack)
+     - until Weezing uses Self Destruct
 
-Menu after Koga:
-- Use all Rare Candies
-- Bike to get Strength
+> Do not revive Nido! Do not heal Nido!         
+> We have purposely allowed Nido to be KO'd (or hit to low health)           
+> so that we can use Rare Candies to bring Nido into red bar for the Gym Rush.          
+
+#### Exit Koga's Gym.
+
+## Mansion
+
+#### Cany Menu (outside of Koga's Gym): 
+- Slot 5 - Use all Rare Candies on Nido
+- Bike East
+
+#### Hop the ledge + enter the Warden's House
+- Talk to the Warden to trade Gold Teeth for HM04.
+- Exit the Warden's house.
 - Fly to Pallet Town
 
-## Pallet Town
+> An NPC will walk in a random direction as you Fly in, possibly blocking your path. 
 
-Menu at the bottom of the water:
-- Super Repel
+Walk down + left to face the water in the bottom left of Pallet Town:
+- <img src="https://i.imgur.com/xEpkSOT.png" width="125">
+
+#### Surf Menu
+- Super Repel 
 - Teach HM03 (Surf) to Squirtle
 - Surf
+     - Surf straight down, move one tile left, continue straight down.
+     - The fisherman has zero vision, he won't see you. 
+- <img src="https://i.imgur.com/yiq3lzt.png">
 
-## Cinnabar Island
 
-- Pick up TM14 (Blizzard)
-- Menu:
-	- Teach HM04 (Strength) to Squirtle over Tackle (slot 1)
-	- Teach TM14 (Blizzard) over BB
-	- Use Repel (THIS IS THE **REPEL** NOT SUPER REPEL)
+#### Inside Mansion:
+
+- 1F: 
+     - Walk straight up + take the stairs.
+- 2F: 
+     - Walk right, up and around to the stairs in the room above you.
+     - <img src="https://i.imgur.com/Lprfchj.png">
+- 3F:
+     - Hit the switch and fall through the hole.
+     - <img src="https://i.imgur.com/6Ygm5Jr.png" width="200">
+- After falling (1F)
+     - Avoid the scientist, skip the item, take the stairs.
+     - <img src="https://i.imgur.com/jd5OoGs.png">
+- Last Floor (B1F):
+     - Pick up [TM14](https://www.extratricky.com/pokeworld/rb/216#19,25) (Blizzard) + **Menu immediately**
+     - (see map below the blizzard menu notes for item locations)
+
+#### Blizzard Menu:
+- Teach HM04 (Strength) to Squirtle over Tackle (slot 1)
+- Teach TM14 (Blizzard) to Nido over Bubblebeam (slot 4 - "down x3")
+- Use **Repel** - Slot 4 (this is the last **REPEL**, do NOT Super Repel)
+
+#### Last floor (B1F) Movement:
+- <img src="https://i.imgur.com/QrcOYpP.png">
+- Hit the switch after Blizzard Menu
+- Hit the next switch.
 - Pick up the [Rare Candy](http://gunnermaniac.com/pokeworld?map=216#10/2)
 - Pick up the [Secret Key](https://gunnermaniac.com/pokeworld?map=216#5/13)
 - Dig out
 
 ## Celadon City
 
-Bike to the gym
+Bike down to cut the tree blocking [the path to Erika's Gym](https://i.imgur.com/oJtdXdj.png). 
+- Enter the gym.  
+- <img src="https://i.imgur.com/cl4CRGn.png">
 
-**Beauty:**
-- Blizz
+#### Beauty's Exeggcute: **Blizz**
 
-**Erika:**
-- EQ
-- Blizz
-- EQ
+| HP after Exeggcute  | Overview of Backup Boom Strats for Erika                                                                                                        
+| ------------------- | --------------------------------------                                            
+| 1-24                | Play Normally --> **EQ, Blizz, EQ**
+| 25-32               | Poké Flute Stall on **Vileplume** until hit, then play normally                                                                          
+| 33+                 | Poké Flute Stall on **Victreebel** until hit, then play noramlly   
+|                     | if needed, Poké Flute is Slot 15 (2 below HM02) 
 
-Fly back to Cinnabar
+#### Erika:
+- Victreebel
+     - EQ
+- Tangela
+     - Blizz
+- Vileplume
+     - EQ
+
+Cut the middle tree, exit the gym, and Fly (D2) back to Cinnabar.
 
 ## Cinnabar Island
 
 Quiz answers: A B B B A B
 
-**Blaine:**
-- X Acc + EQ
-- HD x3
+> No need to toggle when you reach the yes/no text box.     
+> Pressing A will answer YES     
+> Pressing B will answer NO     
 
-Dig out and Bike to Sabrina's gym
+#### Blaine:
+- Growlithe
+     - X Accuracy
+     - EQ
+- Ponyta
+     - HD (use EQ if you accidentally use a HD on Growlithe)
+- Rapidash
+     - HD
+- Arcanine
+     - HD
+
+Dig out and Bike to Sabrina's gym.
+- Northeast corner of Saffron City
+- 1st gym is the fighting dojo, 2nd gym is the correct gym
 
 ## Saffron City
 
-Teleporter puzzle: Top left, Bottom left, Bottom left
+Take the only teleporter pad to enter the puzzle.
 
-**Sabrina:**
+> Avoid the trainers' lines of sight by hugging the bottom walls.
+
+#### Teleporter Puzzle Solution: 
+- Top Left, Bottom Left, Bottom Left
+- (or think: Diagonal, Diagonal, hold Down)
+
+#### Sabrina:
 - EQ x4
 
-Walk back to the teleporter and Dig out and Fly to
+Walk back to the teleporter, Dig out, Fly (U1) to Viridian City, and bike to Giovanni's Gym.
 
 ## Viridian City
 
-**Cooltrainer:**
+<img src="https://pokemon-speedrunning.github.io/speedrun-routes/gen-1/images/classic/Blackbelt.png" width="300">
+
+**Cooltrainer's Rhyhorn:**
 - EQ
 
-[OPTIONAL SAVE: This next fight has a decent chance to die, and reviving will lose red bar so saving is advised]
+#### Optional Save before Blackbelt
+- Blackbelt's Machoke has a decent chance to KO you and reviving will lose red bar so saving is advised.
 
-**Blackbelt:**
-- X Acc + HD
-- Blizz
-- HD
+#### Blackbelt:
+- Machoke
+     - **X Accuracy**
+     - HD
+- Machop
+     - Blizz (or EQ if somehow 0 Blizz are left)
+- Machoke
+     - HD
 
-Leave the gym to reset the trainer
+Leave the gym and immediately reenter to reset the trainer.
 
-Menu after entering the gym again:
-- Elixer
+#### Menu one step up after reentering the gym again:
+- Slot 6 - Elixer
 
 **Giovanni:**
 - EQ x4
-- Blizz (+ Blizz)
+- Rhydon: Blizz (+ Blizz)
 	- Note: Don't go below 2 Blizzards in this fight, use EQ to finish Rhydon if you need to
 
-Menu after leaving the gym:
+> The notes below assume optimal Super Repel locations         
+
+Menu after leaving the gym (+ hopping the ledge):
 - Super Repel
 - Bike
 
-**Rival:**
-- X Acc + Blizz + TB
-- HD x2
-- X Spec (on Growlithe)
-- HD x3
-	- Note: Only if you had 0 Potions in Celadon and bought 3 X Speeds do the following instead:
-	- X Acc + X Speed + Blizz (+ TB), HD x5
-	- Otherwise, the badge boost from the X Spec on Growlithe allows us to outspeed Alakazam.
+> remember to X Special **on Growlithe** in the next fight     
+> the badge boost is required there to outspeed Zam     
+
+**Viridian Rival:**
+- Pidgeot
+     - **X Accuracy**
+     - Blizz + TB
+- Rhyhorn
+     - HD
+- Gyarados
+     - HD
+- Growlithe
+     - **X Special**
+     - HD
+- Alakazam
+     - HD
+- Venusaur
+     - HD
+
+## Badge Check
+
+- Exit the house and Bike. Continue north towards Victory Road. 
+- Menu to enter the water:
+     - Up 1 to Pkmn, D1 to Squirtle, D1 to Surf. 
+- Pick up the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=34#8/90) from the water.
+- Menu after exiting the water:
+     - Super Repel
+     - Bike
 
 ## Victory Road
 
-[Super Repel locations](https://imgur.com/gallery/laeW1PT) and [Victory Road map](https://imgur.com/gallery/vKQYRQZ)
+<img src="https://i.imgur.com/ys46wMK.png">
 
-- Pick up the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=34#8/90) from the water
-- Use a Super Repel one step into the cave
-- Watch a top leaderboard run for how to do the Strength boulder puzzles
-- Use the 2nd Super Repel on [this tile](https://gunnermaniac.com/pokeworld?map=194#5/14) before using Strength
-- After dropping before the last boulder on [this tile](https://gunnermaniac.com/pokeworld?map=194#24/16):
-	- Use Strength
-	- Use a Max Ether on HD
-	- Super Repel
-	- Bike
-- Optional Safety: Pick up the [Full Restore](http://gunnermaniac.com/pokeworld?map=194#26/7)
+#### Menu one step up into cave - "Boulder #1"
+- Use Strength
 
-## E4
+#### Menu to the right of Boulder #2
+- Use Super Repel
+- Use Strength
 
-Don't deposit extra pokes unless you have no more Revives
+#### Menu beneath Boulder #3
+- Use Strength
 
-**Lorelei:**
+> If your repel runs out early, perform the last menu early (don't yolo tiles)
+
+#### Last Menu *after dropping through the hole* - "Boulder #4"
+- Use Strength
+- d2 **Max Ether** on (u1) Nido on Slot 1 (HD)
+- u2 Super Repel
+- Bike
+
+#### Optional (recommended if low on healing items)
+- Pick up the [hidden Full Restore](http://gunnermaniac.com/pokeworld?map=194#26/7) at the end of Victory Road.
+
+## Elite Four
+
+> If you have zero Revives left, deposit Squirtle + Paras; otherwise don't deposit.            
+> Note: if you accidentally let bird be KO'd already, swap to Paras on Lorelei instead of bird for the Trainer AI manip to still work.     
+
+#### Lorelei
 - Dewgong:
-	- Swap to the bird turn 1
-	- Swap back to Nido and X Acc
-	- HD x5
+     - Swap to Bird turn 1 (Dewgong uses Aurora Beam turn 1 on bird)
+     - Swap back to Nido + **Use X Accuracy** (Dewgong uses Rest turn 2)
+- **HD x5**
 
-Before Bruno use a Max Ether on HD
+#### Menu before Bruno
+- Use Max Ether on HD
 
-**Bruno:**
-- X Acc + HD x5
+> Bruno's Onix is unlikely to KO you, but if Onix does manage to KO you with a Slam crit, then       
+> Send out Squirtle/Paras, Revive Nido, swap back to Nido immediately, X Accuracy + HD x5       
+> (no need to let the swapped poke be KO'd here - splitting EXP is okay in this instance)        
 
-Menu before Agatha:
-- 1-18 Super Potion + Potion
-- 19+ Super Potion
-	- If out of Potion, just Super Potion once
-- Rare Candy
+#### Bruno:
+- X Accuracy + HD x5
 
-**Agatha:**
-- Gengar: X Spec + EQ
-	- If you get put to sleep use the Poke Flute, and if you get confused risk it since you would need to X Spec again if you swapped
-- Golbat: Blizz
-	- If you miss Blizz, and Golbat uses Haze, use
-		- 2x TB on Golbat
-		- Consider using a Super Potion on Arbok at 25-60 (or use X Speed if you bought 3)
-		- 25 HP and lower has red bar, and is usually worth taking the risk
-		- You are slower than the last Gengar, so it will have a turn to use a move on you
-	- If you miss Blizz, but Golbat doesn't use Haze, use Blizz again, or TB if out of Blizzards
-- EQ x3
+#### Menu before Agatha:
+- Heal to 122+ HP
+- Super Potion x1-2 (+ Potion)
+- Use Rare Candy on Nido (2 below HM03)
+
+#### Agatha:
+- 1st Gengar: 
+     - **X Special**
+          - If Hypnosis hits, use the Poke Flute (2 below HM02)
+          - If confused, do NOT swap (it is not worth having to re-setup the X Special).
+               - Yolo through confusion by continuing to attempt to get your moves off.
+               - Under 57 HP, use Full Restore, but note that this does not remove confusion.
+     - **EQ**
+- Golbat: 
+     - **Blizz** 
+     - Or **TB x2** if zero Blizz left
+     - If Blizz miss into Golbat using **HAZE** note the following:
+          - HAZE --> Use **TB x2** on Golbat (since Blizz no longer OHKOs)
+          - HAZE --> Agatha's last Pokemon (her 2nd Gengar) will outspeed us and can deal up to 60 damage. 
+          - HAZE + 0 Revives + under 61 HP ---> Full Restore (+ Para Heal if Glared) **on Arbok**; otherwise, yolo
+- Haunter:
+     - EQ
+- Arbok:
+     - EQ
+- 2nd Gengar:
+     - EQ
+
+HP      | Healing Strategy before Lance
+------- | ---------------------------
+4-7     | Super Potion x2 + Potion x2
+8-27    | Super Potion x2 + Potion
+28-48   | Super Potion x2
+49-57   | Super Potion + Potion x2
+58-77   | Super Potion + Potion
+78-98   | Super Potion
+99-106  | Potion x2
+107-127 | Potion
+<img src="https://i.imgur.com/QfIueNL.png" height="200" >
 
 Menu before Lance:
-- Use Elixer
-- Heal using the chart below
-- [OPTIONAL SAVE: Lance is somewhat likely to kill you, so saving is recommended]
+- **Use Elixer**
+- **Heal to 128+ HP**
+- Save the game: Lance is somewhat likely to KO you, so saving is recommended.
 
-HP      | ITEMS
-------- | ---------------------------
-4-6     | Super Potion x2 + Potion x2
-8-26    | Super Potion x2 + Potion
-27-48   | Super Potion x2
-49-56   | Super Potion + Potion x2
-57-76   | Super Potion + Potion
-77-98   | Super Potion
-99-106  | Potion x2
-107-126 | Potion
+> Note: the X Special on **Dragonair** --> Speed Badge Boost required to outspeed Aerodactyl
 
-If you don't have enough Potions, use the next healing option
-- Feel free to use your Full Restore if you picked it up and you want to play really safe
+#### Lance:
+- Gyarados: 
+     - **X Special**
+     - TB
+- Dragonair 1: 
+     - **X Special**
+     - (+ X Accuracy, only if you have 3 X Accuracy left)
+     - Blizz
+- Dragonair 2: 
+     - Blizz
+- Aerodactyl: 
+     - TB
+- Dragonite: 
+     - Blizz
 
-**Lance:**
-- Gyarados: X Spec + TB
-- Dragonair 1: Blizz
-- Dragonair 2: X Spec + Blizz (use X Speed instead if you have one)
-- Aero: TB
-- Dragonite: Blizz
+#### Menu After Lance (before entering the next room):
+- Heal to 45+ HP 
+     - (or to 22+ if you need red bar to PB)
+- Optional: Save the game 
+     - (especially if you don't have an extra X Accuracy + X Special + Revive + alive Squirtle or Paras to sac)
 
-After Lance:
-- Heal to 22+
-- [OPTIONAL SAVE: Saving for Champ can be good if you don't have a spare X Accuracy + X Special + Revive]
+> Animations are automatically turned on when you enter the Champ fight       
+> In red bar, it's faster to HD Rhydon and TB Gyarados      
+> Not in red bar, it's faster to Blizz Rhydon and HD Gyarados      
+> Either strategy is fine, just ensure that you have HDs left to KO Arcanine & Venusaur     
 
-**Champion:**
-- Pidgeot: X Spec
+#### Champion:
+- Pidgeot Turn 1: **X Special**
+- Pidgeot Turn 2: 
 	- If Pidgeot does NOT use Sky Attack turn 1:
-		- Pidgeot: X Acc + HD
+		- Pidgeot: **X Accuracy** + HD
 		- Alakazam: HD
-		- Rhydon: HD
-		- Gyarados: **TB**
+		- Rhydon: **Blizz** (or **HD** if in red bar or 0 Blizz left)
+		- Gyarados: **HD** (must **TB** Gyarados if we used HD on Rhydon)
 		- Arcanine: HD
 		- Venusaur: HD
 	- If Pidgeot begins to use Sky Attack turn 1 (*Pidgeot is glowing*):
 		- Pidgeot: **Blizz**
 		- Alakazam: **EQ**
-		- Rhydon: X Acc + HD x4
+		- Rhydon: **X Accuracy** + HD x4
+
+## Hall of Fame
+
+Clear all of Oak's text.
+- Your Pokemon are registered in the HoF and the in game time is shown.
+- Clear the final two text boxes after IGT is shown and the timing ends when the screen fully fades to white before the credits.
+- Note that the game will not fully save until "THE END" appears on screen at the end of the credits.

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/lass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/lass/README.md
@@ -272,7 +272,7 @@ If you still need Paras: [Post Nerd Backup Paras](../../resources/postnerd-backu
 - Bulba
      - MP + HA (or MP turn 2 if hit by Growl)
 
-> If under ~20 HP after Boat Rival, then either         
+> If under ~20 HP after Bridge Rival, then either         
 > (1) use a Potion (if you have at least 3 left) and go back to get IT again       
 > (2) use the Center again and go back to get IT again       
 

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/lass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/lass/README.md
@@ -138,7 +138,7 @@ If you were not poisoned, then menu one step into Brock's Gym:
     - Leer + HA x2 (+ Tackle)
 - Weedle: [1-9 Potion]
     - Leer + HA x2
-    - (Tackle turn 3 if you hit by String Shot)
+    - (Tackle turn 3 if hit by String Shot)
 - Caterpie:
     - Leer + Tackle + HA (+ Tackle)
 

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/nolass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/nolass/README.md
@@ -33,9 +33,9 @@
 	- (+ MOVE): A situational move used to finish off a pokemon when a damage range is missed
 - IT = Instant Text
 
-### Important Note
+### Important Notes
 - When learning a new move you cannot hit up to make the cursor wrap around to the bottom slot like you can in battle. For example, to teach over Slot 4, you must press down three times. Don't accidentally delete the wrong move.
-- Victory Road can be tricky. While there will be an image embedded showing the optimal strategy, we recommended watching this [easier version of Victory Road / Lorelei Segment Movement](https://youtu.be/AbekvWHeX50). In the description there are timestamps and a link to a video of the optimal movement (~5 seconds faster). 
+- Practice the Lorelei split/segment (Victory Road movement, in particular) - watch and replicate either the [optimal Super Repel locations](https://youtu.be/Dq05fXW7k-4) or this [easier version of Victory Road / Lorelei Segment](https://youtu.be/AbekvWHeX50) (~5 seconds slower).
      - This guide assumes that you will use the optimal strategy in Victory Road, going slower/safer is optional. Note that the slower strategy still works if you accidentally wasted a Super Repel earlier, so it is worth knowing as a backup. 
 
 ### Before you start
@@ -474,7 +474,7 @@ Walk into the bike shop, get the Bike, and exit the shop.
 - MP (Thrash if 0 MP are left)
 - Thrash x3
      - if confused, typically just use Thrash to yolo 
-     - if confused + fought the Gentleman on boat, then you can swap + swap back to split exp with another poke
+     - or you can swap to another poke + swap back right away (splitting EXP here is fine)
 
 **Bug Catcher:**
 - BB (Thrash if you fought the Gentleman)
@@ -492,7 +492,7 @@ Walk into the bike shop, get the Bike, and exit the shop.
 - **Pokemaniac 1**: BB, TB
 - **Pokemaniac 2**: TB
 
-> Save before Oddish Girl if **under 43 HP**.      
+> Optional - Save before Oddish Girl if **under 43 HP**.      
 > Gentleman --> Always skip save & Thrash turn 1.       
 
 #### Oddish Girl
@@ -505,7 +505,6 @@ Walk into the bike shop, get the Bike, and exit the shop.
 After the fight:
 - Use a Repel around [this tile](gunnermaniac.com/pokeworld?map=232#32/16)
 - Use another Repel before the Hiker.
-	- If you were paralyzed, use a Parlyz Heal in one of the Repel Menus.
 	- You can Repel on different tiles if you prefer, we have a lot of extra steps.
 
 **Hiker:**
@@ -514,7 +513,10 @@ After the fight:
 **Jr Trainer F:**
 - Thrash
 
-Exit tunnel and get the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=21#16/53) in the bush to the right and bike straight down after hopping the ledge and avoiding the trainer's line of sight. 
+Exit tunnel and get the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=21#16/53) in the bush to the right.
+- Bike straight down after getting the item.
+- Hop the ledge and avoid the trainer's line of sight by biking behind them as you enter Lavender Town.
+- Immediately exit Lavender to the West.  
 
 ## Route 8
 
@@ -558,14 +560,14 @@ Exit tunnel and get the [hidden Max Ether](https://gunnermaniac.com/pokeworld?ma
 
 #### End of Shopping:
 - Take the elevator to 1F + exit the mart.
-- Bike West + cut the tree. 
+- Bike West + [cut the tree](https://www.extratricky.com/pokeworld/rb/1#144,125). 
 - Bike into the guard house and walk through it. 
-- Walk into the House and talk to the NPC.
-- Get HM02 (Fly) + exit the house.
+- Walk into the [Fly House](https://www.extratricky.com/pokeworld/rb/1#117,121) and talk to the NPC.
+- Get HM02 (Fly) + exit the Fly House.
 
 #### Fly Menu
 - Swap slot 2 Helix Fossil w/ TM07
-- d1 Use a Super Repel
+- d1 Use Super Repel
 - d3 Teach TM48 (Rock Slide) over Mega Punch (slot 1)
 - Swap slot 3 S.S. Ticket w/ X Accuracy
 - d3 Teach HM02 to Bird
@@ -603,7 +605,7 @@ Exit tunnel and get the [hidden Max Ether](https://gunnermaniac.com/pokeworld?ma
 - RS x2
 
 #### Get both Elixers
-- First is a [visible item ball here](http://gunnermaniac.com/pokeworld?map=145#12/10) and [the other is hidden here](http://gunnermaniac.com/pokeworld?map=146#4/12)
+- First is a [visible item ball here](http://gunnermaniac.com/pokeworld?map=145#12/10) and [the other is hidden here](http://gunnermaniac.com/pokeworld?map=146#4/12) on the next floor.
 - Take the heal pad
 
 **Channeler 2:**
@@ -644,9 +646,9 @@ Talk to Mr. Fuji twice to get the Poke Flute
 
 ## Saffron City
 
-- Bike into Silph Co. and take the stairs to Floor 5.
+- Bike into [Silph Co.](https://www.extratricky.com/pokeworld/rb/1#238,130) and take the stairs to Floor 5.
 - Get the [hidden tree Elixer](http://gunnermaniac.com/pokeworld?map=210#12/3)
-- <img src="https://pokemon-speedrunning.github.io/speedrun-routes/gen-1/images/classic/SilphCo1.png">
+- <img src="https://pokemon-speedrunning.github.io/speedrun-routes/gen-1/images/classic/SilphCo1.png" width="325">
 
 **Rocket w/ Arbok:**
 - Thrash x2-3
@@ -722,7 +724,8 @@ Dig out.
 - Teach TM26 (Earthquake) over Thrash (slot 2)
 - Use Bike
 
-> If zero potions left, then swap Helix Fossil with X Special instead. 
+> If zero potions left, then swap Helix Fossil with X Special instead.            
+> Only if zero potions, pick up an item in safari for bag space - such as this [Full Restore](https://www.extratricky.com/pokeworld/rb/217#21,10)            
 
 - Cut both trees to enter Safari Zone
 - <img src="https://pokemon-speedrunning.github.io/speedrun-routes/gen-1/images/classic/CutBothTrees.png" width="350">
@@ -760,7 +763,7 @@ In the Safari Zone:
      - (+ u2 X Special, if Koga uses X-Attack)
      - until Weezing uses Self Destruct
 
-> Do not revive Nido! Do not heal Nido!         
+> Do not revive/heal Nido!       
 > We have purposely allowed Nido to be KO'd (or hit to low health)           
 > so that we can use Rare Candies to bring Nido into red bar for the Gym Rush.          
 

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/nolass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/nolass/README.md
@@ -280,7 +280,7 @@ If you still need Paras: [Post Nerd Backup Paras](../../resources/postnerd-backu
 - Bulba
      - MP + HA (or MP turn 2 if hit by Growl)
 
-> If under ~20 HP after Boat Rival, then either         
+> If under ~20 HP after Bridge Rival, then either         
 > (1) use a Potion (if you have at least 3 left) and go back to get IT again       
 > (2) use the Center again and go back to get IT again       
 

--- a/docs/gen-1/red-blue/main-glitchless/beginner-route/nolass/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/beginner-route/nolass/README.md
@@ -3,195 +3,290 @@
 **FAQ: [Please read the FAQ before learning :)](../../resources/faq.md)**
 
 ### Manip quick reference
+- Watch the [RBY Manip Guide](https://www.youtube.com/watch?v=QirPrbub21g)
 - Nidoran Manip:
-	- [Optimal](../../resources/nido-manip.md) (HIGHLY RECOMMENDED)
-	- [1 A Press](https://youtu.be/2bwQZ6jPxRE)
+	- [7A Press - Optimal](../../resources/nido-manip.md) (Highly recommended)
+	- [1A Press - Easy](https://youtu.be/2bwQZ6jPxRE)
 - Mount Moon Manip:
-	- [Post Hiker Backup Paras](https://pastebin.com/j5gtY4cy) (recommended for first runs)
-		- [Older version](https://pastebin.com/7kcZu3g4) (easier path, but select yoloball)
+	- [Route 3 Moon Manip](https://pastebin.com/tggXpQRC) (Highly recommended, use any of the backups below if you fail it)
+	- [Post Hiker Backup Paras v1](https://pastebin.com/7kcZu3g4) ([2A Press Path](https://i.imgur.com/jp61CLR.png), [video w/ Select yoloball inputs](https://youtu.be/atQiH670ENs))
+	- [Post Hiker Backup Paras v2](https://pastebin.com/j5gtY4cy) (7A press, normal yoloball)
+	- Grogir's [Post Zubat Backup Paras](https://pastebin.com/5rKmACtf) 
 	- [Post Nerd Backup Paras](../../resources/postnerd-backup-paras.md)
-	- [Route 3 Moon Manip](https://pastebin.com/tggXpQRC)
-	- [Entr's Moon Manip](https://pastebin.com/jnj9j47S)
+	- [Entr's Full Moon Manip](https://pastebin.com/jnj9j47S) (Not optimal for this route)
 - Surge Cans Manip:
-	- [Optimal](https://www.youtube.com/watch?v=8Pa2f2WxCe4)
+	- [Optimal Cans Manip](https://www.youtube.com/watch?v=8Pa2f2WxCe4)
+      - 58/60 success rate with 2A presses
+      - 57/60 success rate with zero A presses (same path, same cans)
+      - If this cans manip fails there is no need to resave, just hard reset and do the other version (it'll work because they don't share any failure frames).  
 	- [Palette Cans](https://youtu.be/_tWhfBITf_g) (allows you to see through Rock Tunnel by changing the palette)
-	- [60/60 Cans](https://www.youtube.com/watch?v=T6pXrZ9_Vq0) (slightly slower, but great success chance)
+	- [60/60 Cans](https://www.youtube.com/watch?v=T6pXrZ9_Vq0) (slightly slower + harder, but great success chance)
 
 ### Good documents
 - [Defensive Damage Ranges](../../resources/defensive-ranges.md)
 - [Offensive Damage Ranges](../../resources/offensive-ranges.md)
 - [Safety-oriented HP Strats](../../resources/hp-strats-for-races.md)
+- [Trainer Data Sheet](https://www.dropbox.com/scl/fi/an4xn77nxpyu1noz453nj/Pokemon-Red-trainer-guide.xlsx?rlkey=qi5v6pnrie4xy0e9hxjjiwkfj&e=1&dl=0)
 
 ### Glossary
-- Moves: HA = Horn Attack, MP = Mega Punch, BB = Bubblebeam, WG = Water Gun, TB = Thunderbolt, Blizz = Blizzard, PS = Poison Sting, HD = Horn Drill, RS = Rock Slide
+- Moves: TW = Tail Whip, HA = Horn Attack, PS = Poison Sting, WG = Water Gun, MP = Mega Punch, BB = Bubblebeam, TB = Thunderbolt, RS = Rock Slide, HD = Horn Drill, Blizz = Blizzard.
 	- (+ MOVE): A situational move used to finish off a pokemon when a damage range is missed
 - IT = Instant Text
 
+### Important Note
+- When learning a new move you cannot hit up to make the cursor wrap around to the bottom slot like you can in battle. For example, to teach over Slot 4, you must press down three times. Don't accidentally delete the wrong move.
+- Victory Road can be tricky. While there will be an image embedded showing the optimal strategy, we recommended watching this [easier version of Victory Road / Lorelei Segment Movement](https://youtu.be/AbekvWHeX50). In the description there are timestamps and a link to a video of the optimal movement (~5 seconds faster). 
+     - This guide assumes that you will use the optimal strategy in Victory Road, going slower/safer is optional. Note that the slower strategy still works if you accidentally wasted a Super Repel earlier, so it is worth knowing as a backup. 
+
 ### Before you start
 - Clear any existing save file by pressing Up + B + Select on the game title screen
-- Set your options to fast text and animations OFF
+- Options: Text Speed **Fast** and Animations **Off**
 
 ## Pallet Town
 
-- Name yourself and rival 'A'
-- Pick Squirtle and name it 'A'
+- Name yourself and rival 'A' (or any one-character name)
+- Pick Squirtle (middle ball) and name it 'A'
 
-**Rival 1:**
-- Tail Whip + spam Tackle
+#### Rival 1
+- TW + spam Tackle
+
+> **L6 Squirtle Stats**      
+> 10 ATK --> TW x3 on Weedle Guy     
+> 11 SPC --> likely bad Special for Brock      
+> No need to reset over bad Squirtle stats, just be aware of them.       
+
+## Parcel Quest
+
+> Go up Route 1 to get Oak's Parcel from Viridian Mart.    
+> Return to Oak's Lab, give him the Parcel, and get the Pokedex.     
+> Go back up Route 1 (back to the Viridian Mart).      
+
+KO **one** L2 or L3 encounter at some point during these trips up and down Route 1 by **spamming Tackle**
+- L2-3 Rat or L2 Pidgey are the easiest to KO without taking too much damage.
+- L3 Pidgey is okay too, but deals a lot of damage to us. For this reason, run away from L3 Pidgey on your first pass of Route 1 with the hopes of seeing a better encounter later.
+- Run from all L4-5 encounters and run from all encounters after you get EXP.
+- This early EXP will give Squirtle an extra level up at the end of Viridian Forest which gives us the move Bubble in time for Brock.
 
 ## Viridian City
 
-Get XP from one encounter in Route 1
-- During the parcel quest kill one encounter from a level 2 Rat, level 3 Rat, or a level 2 Pidgey. You can fight level 3 Pidgeys but you will take a bit of damage if you have a lower attack (10-11 at level 6) Squirtle. This early XP will get you Bubble for Brock
-
-Shopping:
-- 4 Poke Balls (This does require you to get consistent at manip yoloballs, you can buy 5 and 1 less Potion later on)
+Viridian Mart:
+- Buy **4 Poke Balls**
+     - (or buy 5 Poke Balls and buy 1 less Potion later)
 
 Nidoran Manip:
-- [Optimal (HIGHLY RECOMMENDED)](../../resources/nido-manip.md)
-- [1 A Press](https://youtu.be/qPzSWHyMuW8)
+- [7A Press - Optimal (Highly Recommended)](../../resources/nido-manip.md)
+- [1A Press - Easy](https://youtu.be/2bwQZ6jPxRE)
 
 Get the [hidden Tree Potion](https://gunnermaniac.com/pokeworld?map=1#54/166)
 
+<img src="https://i.imgur.com/H8JVzPL.png" height="100" >
+
 ## Viridian Forest
 
-- Walk [this path](http://gunnermaniac.com/pokeworld?map=51#17/47/UUUURURRRRRRRRUUUUUUUULUURRUUUUUUUUUUUULLUUUUUUUUAUUULLLLLLLLDDDDDDDLLLLUUUUUUUUUUUUULLLLLLDDDDDDDDDDDDDDDDDDDLLLLLLUUUA) in the forest and pick up the Antidote and the hidden Potion along the way
+- Walk the path below in the forest to decrease the chance of getting wild encounters.
+- Pick up the Antidote and the hidden Forest Potion (in front of Weedle Guy).
 
-**Weedle Guy:**
-- Tail Whip x2 + spam Tackle [1-6 Potion]
-- Check your leveled up stats after this fight, if you have 13 special you have bad special, if you have 14 or 15 you have good special
+<img src="https://i.imgur.com/9wWTgkB.png"> 
 
-If you were poisoned do the following:
-- Swap Nidoran and Squirtle (Nidoran should be the lead pokemon)
-- Antidote
-- 1-15 Potion
+> Note that only the tiles marked in red on the map can generate encounters. 
+
+**Weedle Guy:** [1-6 HP: Potion]
+- TW x2 + spam Tackle
+    - TW x3 if Bad ATK (10 ATK @L6)
+- Check your leveled up Special stat at the end of this fight (SPC is at the very bottom).
+    - 13 SPC @L8 --> Bad Special (likely to take 3 Bubbles instead of 2 to KO Brock's Pokemon)
+
+If you were poisoned, then menu immediately after the fight:
+- Swap Squirtle with Nidoran
+- Potion Squirtle to 16+ HP
+- Use the Antidote
+
+> If you were not poisoned, then delay this menu until one step into Brock's gym      
+> (saves time this way, but it's fine if you do it earlier).       
+> Note that swapping Nido to the lead is essential to swap-train Nido against Brock's Geodude & Onix.        
+> --> Nido will reach L8 and learn Horn Attack after Brock's Onix.   
 
 ## Pewter City
 
-Shopping:
-- 8 Potions
+Pewter Mart:
+- **Buy 8 Potions**
+     - (or buy 7 Potions if you bought 5 Poke Balls earlier)
 
-If you weren't poisoned do the following:
-- Swap Nidoran and Squirtle (Nidoran should be the lead pokemon)
-- 1-15 Potion and toss Antidote
-- [OPTIONAL SAVE IF YOU HAVE BAD SPECIAL]
+If you were not poisoned, then menu one step into Brock's Gym:
+- Swap Squirtle and Nidoran
+- Potion Squirtle to 16+ HP
+- Toss the Antidote
+- [Optional: Save before Brock if you have Bad Special (13 SPC @L8)]
 
-**Brock:**
-- Geodude [1-8 Potion]
-	- Swap to Squirtle, then spam Bubble
-- Onix [1-12 Potion]
-	- Swap to Squirtle
-		- IF ONIX USES BIDE: Tail Whip x2
-	- Spam Bubble
+#### Brock:
+- Geodude: [1-8 Potion]
+   - Swap to Squirtle + Bubble x2-3
+        - Say Yes + swap back to Nido
+- Onix: [1-12 Potion, 1-14 after Screech]
+	 - Swap back to Squirtle + Bubble x2-3
+        - TURN 1 BIDE --> TW x2
+        - If you Bubble after BIDE, keep using Bubble (do not Potion - due to a gen 1 bug, using Potion after a damaging move will cause Bide to KO)
 
-Options: Battle Style to Set before leaving Brock's gym
+**Options**: Battle Style to **Set** before leaving Brock's gym
 
 ## Route 3
 
-**Bug Catcher 1:**
-- Caterpie: Leer + HA x2 (+ Tackle)
-- Weedle: Leer + HA x2
-	- Leer + HA + Tackle if you got String Shot hit OR Tackle will always kill
-- Caterpie: Leer + HA + Tackle
+<img src="https://i.imgur.com/2xwVbXv.png">
 
-Menu:
-- Potion to 28+
+**Bug Catcher 1:**
+- Caterpie:
+    - Leer + HA x2 (+ Tackle)
+- Weedle: [1-9 Potion]
+    - Leer + Tackle x3
+    - (can HA after 1st Tackle if hit by String Shot)
+- Caterpie:
+    - Leer + Tackle + HA (+ Tackle)
+
+#### Menu before Shorts Guy:
+- Potion to 28+ HP
 - Toss Antidote if you still have it
 
 **Shorts Guy:**
-- Rat: [1-15 Potion]
+- Rat: [1-15 Potion, 1-18 if @-2 DEF]
 	- Leer + HA x2
-- Ekans: [1-4 Potion, or 1-5 at -2 defense]
+- Ekans: [1-5 Potion, 1-6 if @-2, 1-8 if @-3]
 	- Leer + HA x2
-		- Potion turn 1 of Wrap if you don't live 4 or 5 turn Wrap
+		- In general, **Potion** immediately after turn 1 of **Wrap** hit.
+    - Since Wrap lasts 2-5 turns, we avoid chain wrap by using the Potion right away.
 
-**Bug Catcher 2:**
-- Weedle:
-	- HA x2 (Tackle is a range to kill turn 2)
-- Kakuna:
-	- Spam HA, finish with Tackle
-- Caterpie: [1-5 Potion]
-	- HA x2 (Tackle turn 2 if Weedle hit 2 String Shots)
-- Metapod:
-	- HA x2 + Tackle
+> Bug Catcher 2 Weedle      
+> Tackle turn 2 if you see this HA high roll into a string shot hit     
+> <img src="https://i.imgur.com/ic8Y6a9.png" width="150">        
+> Always Tackle turn 2 if the HP bar is lower than this          
 
-1-5 Potion x2 before next fight
-
-**Bug Catcher 3:**
-- Caterpie:
+#### Bug Catcher 2
+- **Weedle**:
 	- HA x2
-- Metapod: (Note: You need at least 2 HAs for after this fight)
-	- Spam HA, finish with Tackle
+- **Kakuna**:
+	- HAx2-3 + Tackle x1-2
+- **Caterpie**: [1-5 Potion]
+    - HA x2 (only Tackle turn 2 if hit by 2+ stringshots before 1st HA hits or if HA crits)
+- **Metapod**:
+	- HA x2 + Tackle (only HA turn 3 if you were slower than Metapod due to 2-3+ string shots)
 
-Catch a flyer:
-- Tackle then toss a Ball at any flyer except L8 Pidgey where you HA then toss a Ball
-- Exception: If only 2 HAs are left, then weaken L8 Pidgey with Leer + Tackle
+> 1-5 HP: **Potion** before the next fight
+
+#### Bug Catcher 3
+- Caterpie:
+    - HA x2
+- Metapod:
+    - HA x3-4 + Tackle x1-2 (switch to spamming Tackle if only 3 HAs are left) 
+
+#### Catch a flyer
+- <img src="https://i.imgur.com/FQbywuv.png" width="225"> 
+- Step Up/Down (or Left/Right), but do NOT step over the imaginary line in the image above.
+- This would load the Jigglypuff Lass' Sprite on screen (which would prevent Route 3 Moon Manip from working).
+- **L8 Pidgey**:
+	- **Leer + Tackle**, then throw balls
+- **any other Bird**:
+	- **Tackle**, then throw balls
 
 ## Mount Moon
 
-- Do not learn a full Moon Manip for your first runs, start by learning [Post Hiker Backup Paras](https://pastebin.com/j5gtY4cy) (or the [older version](https://pastebin.com/7kcZu3g4)) and walk through the first floor normally ([movement map](https://i.imgur.com/xzgmNBk.jpeg)). You will choose later if you want to learn [Route 3 Moon](https://pastebin.com/tggXpQRC) (optimal for this route) or [Entr Moon](https://pastebin.com/jnj9j47S) (slightly less optimal, but still perfectly fine). There is also a [Post Nerd Backup Paras](../../resources/postnerd-backup-paras.md) you can learn.
+#### Menu on the Route 3 Save Tile
+- Potion to 22+ HP (or 36+ HP if confident with yolo ball)
+
+#### Save & Do [Route 3 Moon Manip](https://pastebin.com/tggXpQRC)
+- Hold a palette selection through bios immediately after Hard Reset
 - Get [TM12 (Water Gun)](https://gunnermaniac.com/pokeworld?map=59#5/32), [Rare Candy](https://gunnermaniac.com/pokeworld?map=59#35/31), [Escape Rope](https://gunnermaniac.com/pokeworld?map=59#36/23), [TM01 (Mega Punch)](https://gunnermaniac.com/pokeworld?map=61#29/5) and [Moon Stone](https://gunnermaniac.com/pokeworld?map=59#2/2)
-- Avoid catching wild Paras as the catch is not guaranteed even at low HP, catch the manipped one instead
+- Performing a full Moon Manip is not required when starting out, but it doesn't hurt to attempt it and see how far you get.
+- If you fail the manip at some point (or get an IGT failure), then just run from the extra encounters until you get to one of the backup manip locations below.
+- Avoid trying to catch a random wild Paras since the catch is not guaranteed even at low HP, catch a manipped one instead.
 
-Menu before walking in front of the Rocket:
+#### _PoY's [Post Hiker Backup Paras v1](https://pastebin.com/7kcZu3g4)
+- If Route 3 Manip has failed, then save immediately after going through the ladder after Moon Stone
+- 2A Presses, [Select Yoloball - click here for a video of the inputs](https://youtu.be/atQiH670ENs)
+- <img src="https://i.imgur.com/2OPBuoM.png" width = "200"> <img src="https://i.imgur.com/Z7KX0B8.png" width = "250">
+
+#### Grogir's [Post Zubat Backup Paras](https://pastebin.com/5rKmACtf) 
+- **Hold A on the Bios Screen** immediately after Hard Reset
+- <img src="https://i.imgur.com/dk5eT3x.png" width = "300">
+
+#### Menu before walking in front of the Rocket:
 - Toss any remaining Poke Balls (ONLY IF YOU HAVE A PARAS)
-- Potion to 36+
-- (Optional but recommended) Save
+- Potion to 36+ HP
+- Optional: Save the game.
 
-**Rocket:**
-- This fight will change depending on how many Horn Attacks you have left
-- 1 HA:
-	- Rat: Leer + Tackle x2 (+ PS)
-	- Zubat: Leer + Tackle + HA (+ Tackle)
-- 2 HA:
-	- Rat: Leer + HA + Tackle (or PS turn 3 if Tail Whip hit or PS always kills)
-	- Zubat: Leer + Tackle + HA (+ Tackle)
-- 3 HA:
-	- Rat: HA x2 (+ PS)
-	- Zubat: Leer + Tackle + HA (+ Tackle)
-- 4 HA:
-	- Rat: HA x2 (+ PS)
-	- Zubat: Leer + HA x2
-- 5+ HA:
-	- Rat: HA x2 (+ PS)
-	- Zubat: HA x3 (+ Tackle)
+#### Moon Rocket (HA Count Remaining --> Strategy):
+- Rattata: [1-16 Potion]
+    - 3+ --> **HA x2 (+PS)**
+    - 2 --> **Leer + HA + Tackle** or PS
+    - 1 --> **Leer + Tackle x2 + PS**
+- Zubat:
+    - 3+ --> **HA x3**
+    - 2 --> **Leer + HA x2**
+    - 1 --> **Leer + Tackle + HA** (+ Tackle)
 
-Menu after defeating Rocket:
+#### Moon Rocket's Zubat (When to Potion)
+| DEF  | Not confused  | Confused      |
+| ---- | ------------- | ------------- |
+| -0   |      1-7      |     1-16      |
+| -1   |      1-11     |     1-26      |
+| -2   |      1-13     | Yolo or swap to sac a low-HP-mon |
+
+> After Rocket, take one step right and Menu (open the bag)        
+> Be very careful to NOT use the escape rope       
+
+#### Moon Menu
 - Use Rare Candy
 - Teach TM12 (Water Gun) over Tackle (slot 2)
 - Use Moon Stone
 - Teach TM01 (Mega Punch) over Leer (slot 1)
 
-Talk to the Nerd
+Walk UP and talk to the Super Nerd from below.
 
-**Super Nerd:** (if you are out of HA just MP instead)
-- Grimer: MP + HA [Note: Water Gun can kill if you get a good MP roll, if so use WG over MP or HA]
-- Voltorb: MP + PS
-- Koffing: HA + MP if you have an HA, otherwise MP x2
+> If you encounter a Paras or a Geodude, KO it for EXP (PS for Paras, WG for Geodude).       
+> This [Moon EXP](https://docs.google.com/document/d/1ZHm2fto6N0BR9_HupIvUaTnefH38pIztrLcEZwV_NYs/edit?usp=sharing) will improve Bridge ranges, let you HA both Bridge Zubat, + usually Thrash 2nd Oddish before Bill.       
+> This encounter can be before or after the Super Nerd, doesn't matter.        
 
-If you encounter a Paras or a Geodude, faint it for EXP (PS for Paras, WG for Geodude). This [Moon EXP](https://pastebin.com/8gP8HZY9) will improve some ranges.
+**Super Nerd**:
+- Grimer: (HA or MP turn 2 if turn 1 is a low roll)
+	- MP + WG 
+- Voltorb:
+	- MP + PS
+- Koffing: (WG turn 2 if turn 1 is a crit)
+	- HA + MP or MP x2 
 
 If you still need Paras: [Post Nerd Backup Paras](../../resources/postnerd-backup-paras.md)
+- Hold a palette selection through bios immediately after Hard Reset
+- 2A Presses
+
+<img src="https://i.imgur.com/rRnoayt.png" width="225"> <img src="https://i.imgur.com/MFBagiA.png" width="125">
 
 ## Nugget Bridge
 
-- Use the center
+- Use the Pokemon Center in Cerulean City.
 - Get IT (Instant Text)
-	- You talk to the bike salesman and mash B through his text, this will set all text to instant. Things that kill instant text are Yes/No textboxes, opening the menu in and out of fights.
+     - Talk to the bike salesman and mash B through his text, this will set all text to instant.
+     - IT is lost any time you get a Yes/No textbox or anytime you open the menu either in or out of fight.
+     - During first runs especially, it's okay to lose IT at some point in order to play safely. 
 - Pick up the [hidden Rare Candy](http://gunnermaniac.com/pokeworld?map=1#235/44)
 
-**Bridge Rival:**
-- Pidgeotto: HA x3 (if you get some bad rolls use MP to kill)
-	- If you get hit by 2 Sand-Attacks swap to your bird and let it die
-		- Try to put Pidgeotto in HA range before doing this to avoid getting Sand-Attacked again after swapping back
-		- Get IT again after the fight
-- Abra: HA
-- Rat: MP
-- Bulba: MP + HA (MP if you get Growled or miss a bunch into Leech Seed healing)
+#### Bridge Rival:
+- Pidgeotto
+    - HA x3 (MP turn 3 if bad HA rolls)
+	  - If you get hit by 2 Sand-Attacks swap to your bird and let it be KO'd
+          - Try to put Pidgeotto in HA range before doing this to avoid getting Sand-Attacked again
+          - Swap --> return to the Bike Shop after Rival, Potion (if needed), and reget IT
+- Abra
+     - HA
+- Rat
+     - MP (or HA if hit by TW x2)
+- Bulba
+     - MP + HA (or MP turn 2 if hit by Growl)
+
+> If under ~20 HP after Boat Rival, then either         
+> (1) use a Potion (if you have at least 3 left) and go back to get IT again       
+> (2) use the Center again and go back to get IT again       
 
 **BC:**
 - MP (+ PS)
-- MP (if you missed MP into String Shot hit use HA)
+- MP (HA if hit by String Shot)
 
 **Lass:**
 - MP (+ PS)
@@ -200,20 +295,23 @@ If you still need Paras: [Post Nerd Backup Paras](../../resources/postnerd-backu
 **Youngster:**
 - MP
 - MP (+ PS)
-- MP (HA if you fought the extra Moon encounter)
+- MP (HA w/ Moon EXP)
 
 **Lass:**
 - MP (+ PS)
 - HA x2
 
-**Mankey:** [Note: Mankey is 1/3 to Karate Chop and does 12-15, healing is an option but is slow because you lose IT]
-- 1-7 MP (+ PS)
-- 8-27 HA x2 [Note: PS can kill if you get a good HA roll, if so use PS over the second HA]
-- 28+ MP (+ PS)
+> 1-7 HP: Potion before the next fight (do not go back for IT, it's too far away now)      
+> Note: Mankey is 1/3 to Karate Chop and typically does 12-14 dmg, so healing is recommended
+
+**Mankey:**
+- 8-14: Potion turn 1 (or HA + HA/PS to yolo)
+- 15-27: HA + HA/PS
+- 28+: MP (+ PS)
 
 **Rocket:**
 - MP
-- MP (HA if you fought the extra Moon encounter)
+- MP (HA (+PS) w/ Moon EXP)
 
 ## Route 25
 
@@ -224,17 +322,21 @@ If you still need Paras: [Post Nerd Backup Paras](../../resources/postnerd-backu
 - MP
 - HA x2
 
+> 1-7 HP: Potion before the Hiker
+
 **Hiker:**
 - WG
 - WG
-- MP (+ PS)
+- MP (+ PS) (or @16-20 HP: HA + PS)
 - WG
+
+> 1-6 HP: Potion turn 1 on Lass' 1st Oddish
 
 **Lass:**
 - MP
 - HA
-- MP (HA if you fought the extra Moon encounter)
-	- Teach Thrash over Water Gun (slot 2)
+- MP (or Thrash w/ Moon Exp)
+	- Teach Thrash over Water Gun
 
 Menu after Bill:
 - Use Rare Candy
@@ -242,22 +344,31 @@ Menu after Bill:
 
 ## Cerulean City
 
-- Use the center
+- **Use the Pokemon Center**
 - Get IT again
 
 **Dig Rocket:**
-- Thrash
+- Thrash x1-2
+- Thrash x1-2 (+PS)
+
+> Important Note: after defeating Misty she gives us TM11 (Bubblebeam)        
+> TM11 will be taught over Slot 4 Poison Sting at some point before Surge      
+> Remember that when teaching moves you can NOT wrap around to slot 4 like you can when using moves in fight.      
+> Remember to hit Down x3 when teaching over a move like Poison Sting in Slot 4 to avoid overwriting the wrong move       
+
+Enter Misty's Gym + avoid the swimmer by going Up then Left + around.
 
 **Jr Trainer F:**
-- Thrash
+- Thrash x2
 
-**Misty:**
-- Thrash
-	- If you are ever alive and confused swap to another poke (bird) and let it die
+#### Misty:
+- Thrash x1
+- Thrash x2-3
+	- If confused on Starmie, swap to bird and let it be KO'd.
 
 If 1-15 after Misty (or 16-24 and you want to play safely):
-- Potion
-- Teach TM11 (Bubblebeam) over PS (slot 4)
+- Potion (or use the center again to avoid using your last potion)
+- Teach TM11 (Bubblebeam) over PS (slot 4 - D3)
 - Get IT again
 
 ## Vermilion City
@@ -268,76 +379,102 @@ If 1-15 after Misty (or 16-24 and you want to play safely):
 **Jr Trainer M:**
 - Thrash
 
-If 1-12 after this fight:
+If 1-12 after this fight (or 13-22 to be extra safe):
 - Potion
-- Teach TM11 (Bubblebeam) over PS (slot 4)
+- Teach TM11 (Bubblebeam) over PS (slot 4 - D3)
 
-**Boat Rival:**
-- Pidgeotto:
+#### Boat Rival
+- Pidgeotto
 	- HA x2 (HA + BB if taught; Potion turn 2 if 1-6)
-	- If you get Sand-Attacked swap to another pokemon and let it die
-- Rat:
+	- If you get Sand-Attacked swap to Bird or Squirtle and let them be KO'd
+- Raticate
 	- 1-6 Potion
-	- 7-22 MP [Note: Potion on 7-12 is extra safe]
+	- 7-22 MP [Note: can Potion on 7-12 (or 13-22) to be extra safe against Hyper Fang]
 	- 23+ HA + PS or BB x2
-- Kadabra:
+- Kadabra
 	- 1-6 HA Kadabra & Potion turn 1 on Ivysaur, then Thrash
-	- 7+ Thrash Kadabra
+	- 7-12 Thrash Kadabra (or HA Kadabra + Pot on Ivy to be extra safe)
+  - 13+ Thrash Kadabra
+- Ivysaur
+  - Thrash x2 
 
 Talk to the Captain to get HM01
 
-Depending of your HP, you may fight the Gentleman in [this room](https://gunnermaniac.com/pokeworld?map=96#21/11) with Thrash then pick up the Rare Candy
+Depending of your HP, you may fight the Gentleman in [the 3rd Cabin from the Right](https://gunnermaniac.com/pokeworld?map=96#21/11) with Thrash then pick up the Rare Candy.
 
-| HP    | Strategy                                |
-| ----- | --------------------------------------- |
-| 1     | Skip Gentleman, use Potion in Cut Menu  |
-| 2-8   | Do Gentleman                            |
-| 9-24  | Do Gentleman if you want to play safely |
+| HP     | Strategy                                              |
+| ------ | ----------------------------------------------------- |
+| 1      | Do Gentleman + use a Potion at the start of Cut Menu  |
+| 2-14   | Do Gentleman                                          |
+| 15-24  | Do Gentleman if you want to play extra safely         |
 
-> Important note for shopping: **always buy items in the order that they are listed in this guide**. Doing so is both the fastest way to buy the items and sets up our inventory in the correct order.  
+> Important note for shopping: **always buy items in the order that they are listed in this guide**.       
+> Doing so is both the fastest way to buy the items and sets up our inventory in the correct order.        
 
-Shopping:
-- Buy:
-	- 6 Repels
-	- 4 Parlyz Heals
+#### Vermillion Mart:
+- 6 Repel
+- 4 Parlyz Heal
 
-Menu before Cut bush:
-- Teach TM11 (Bubblebeam) over PS (slot 4)
+> Walk to the tree guarding Surge's Gym
+
+#### Cut Menu:
+- Teach TM11 (Bubblebeam) over PS (slot 4 - D3)
 - [Rare Candy if you fought the Gentleman]
 - Teach HM01 to Paras
 - Teach TM28 (Dig) to Paras
 - Use Cut
 
-Surge Cans Manip:
-- [Optimal](https://www.youtube.com/watch?v=8Pa2f2WxCe4)
-- [Palette Cans](https://youtu.be/_tWhfBITf_g) (allows you to see through Rock Tunnel by changing the palette)
-- [60/60 Cans](https://www.youtube.com/watch?v=T6pXrZ9_Vq0) (slightly slower, but great success chance)
+#### Surge Cans Manip:
+- [Optimal Cans](https://www.youtube.com/watch?v=8Pa2f2WxCe4)
+     - 57/60 success rate w/ zero A pressses
+     - 58/60 success rate w/ the two A presses outside
+- [Palette Cans](https://youtu.be/_tWhfBITf_g)
+     - 59/60 success rate + allows you to see through Rock Tunnel by changing the palette with an Up+B tap.
+- [60/60 Cans](https://www.youtube.com/watch?v=T6pXrZ9_Vq0)
+     - slightly slower and less beginner friendly due to a start flash and 3 A presses
 
 **Surge**
 - Voltorb:
 	- 1-24 Thrash
-	- 25+ BB + HA
+	- 25+ BB x2
 - Pikachu:
 	- Thrash
 - Raichu:
-	- If you are confused and dead to a self hit, swap to your bird or Squirtle
+	- Thrash x2
+        - If you are confused and dead to a self hit, swap to sac your bird or Squirtle
 
-Get the Bike Voucher and use Dig on Paras
+</td><td>
 
-## Cerulean City
+Surge's Raichu    | Hit Self | w/gentleman candy 
+----------------- | -------- | -----------------
+&nbsp;            | **14**   | 15
+w/Growl           | **9**    | 10
+w/Screech         | **29**   | 31
+w/Screech & Growl | **17**   | 18
 
-- Get the Bike
-- Menu:
-	- Swap (using select) slot 1 with the Bike
-	- Teach TM24 (Thunderbolt) over HA (slot 3)
-	- Use the Bike
+Exit the gym, get the Bike Voucher from the guy in the Fan Club, and then use Dig.
+
+## Warp back to Cerulean City
+
+> Note: items are swapped around using the Select button       
+> Bike Menu below is the first instance of an item swap in this guide       
+
+Walk into the bike shop, get the Bike, and exit the shop.
+
+#### Bike Menu:
+- Swap slot 1 Potion w/ Bike
+- Teach TM24 (TB) over Horn Attack (slot 3)
+- Bike + cut both trees (see below)
+
+<img src="https://pokemon-speedrunning.github.io/speedrun-routes/gen-1/images/classic/Bike4TTG.png">
 
 ## Route 9
 
-**4 Turn Thrash Girl:**
-- MP
-- Thrash
-	- If you run out of MP just Thrash, you will be 25% to hit yourself on the last poke
+#### 4 Turn Thrash Girl:
+- MP (Thrash if 0 MP are left)
+- Thrash x3
+     - if confused, typically just use Thrash to yolo 
+     - if confused + fought the Gentleman on boat, then you can swap + swap back to split exp with another poke
 
 **Bug Catcher:**
 - BB (Thrash if you fought the Gentleman)
@@ -345,32 +482,31 @@ Get the Bike Voucher and use Dig on Paras
 
 ## Rock Tunnel
 
-[Map of both floors](https://imgur.com/gallery/uoueIjq)
+<img src="https://i.imgur.com/gs5N4V5.png">
 
-Menu after taking 1 step down:
-- Scroll down and use a Repel
+> Quick Reference     
+> Slot 7: Repel      
+> Slot 8: Parlyz Heal     
+> Slot 9: Potion      
 
-**Pokemaniac 1:**
-- BB
-- TB
+- **Pokemaniac 1**: BB, TB
+- **Pokemaniac 2**: TB
 
-**Pokemaniac 2:**
-- TB
+> Save before Oddish Girl if **under 43 HP**.      
+> Gentleman --> Always skip save & Thrash turn 1.       
 
-[Optional Save if 1-17 and you did not fight the Gentleman]
-
-**Oddish Girl:**
-- If you fought the Gentleman, Thrash. The ranges are guaranteed
-- 18-22 TB + Thrash
-- Otherwise, just Thrash
-	- If you get put to sleep, Potion at 1-5
-	- If paralyzed, keep using Thrash
+#### Oddish Girl
+- 1-17 or 23+ HP ---> **Thrash turn 1**
+- 18-22 HP ---> **TB + Thrash**
+     - Sleep ---> 1-13 HP: Potion
+     - Para'd ---> keep Thrashing, but 1-14 HP: Potion
+     - Do not Para Heal in fight, use it in the next Repel Menu instead.
 
 After the fight:
-- Use one Repel [here](https://gunnermaniac.com/pokeworld?map=232#25/19)
-- Use another Repel [here](https://gunnermaniac.com/pokeworld?map=232#8/17)
-	- If you were paralyzed, use a Parlyz Heal now
-	- You can delay these 2 Repels up to ~10 tiles
+- Use a Repel around [this tile](gunnermaniac.com/pokeworld?map=232#32/16)
+- Use another Repel before the Hiker.
+	- If you were paralyzed, use a Parlyz Heal in one of the Repel Menus.
+	- You can Repel on different tiles if you prefer, we have a lot of extra steps.
 
 **Hiker:**
 - BB x3
@@ -378,69 +514,97 @@ After the fight:
 **Jr Trainer F:**
 - Thrash
 
-Get the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=21#16/53)
+Exit tunnel and get the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=21#16/53) in the bush to the right and bike straight down after hopping the ledge and avoiding the trainer's line of sight. 
 
 ## Route 8
 
-**Gambler:**
+#### Gambler:
 - Growlithe:
 	- 1-8 Potion
 	- BB
 - Vulpix: Thrash
 
+> Carefully [avoid optional trainers](https://i.imgur.com/3TbEDS8.png) and enter the underground. 
+
 ## Underground
 
+- Take the stairs down + get on the Bike.
 - Get the [hidden Elixer](http://gunnermaniac.com/pokeworld?map=121#21/5)
 - Get the [hidden Nugget](http://gunnermaniac.com/pokeworld?map=121#12/2)
+- Exit the underground + get back on the Bike. 
 
 ## Celadon City
 
-Shopping:
+> If you fought the Gentleman on the boat, you can buy +1 X Accuracy. 
+
+#### Celadon Mart:
 - Floor 2:
 	- Sell TM34
 	- Sell both Nuggets
 	- Buy TM07
-	- Buy 7 Super Repels
-	- Buy 4 Super Potions
-	- Buy 2 Revives
+	- Buy 7 Super Repel
+	- Buy 4 Super Potion
+	- Buy 2 Revive
 - Floor 4:
-	- Buy Poke Doll
+	- Buy 1 Poke Doll
 - Roof:
-	- Buy a Soda Pop and trade it to the girl
-	- Come back and buy a Fresh Water
+	- Buy a **Soda Pop**
+             - trade it to the girl for TM48 (RS)
+	- Walk back to the vending machine and buy a **Fresh Water**
 - Floor 5:
-	- Buy 12 X Accs
-	- Buy 9 X Specs (7 if you have 0 Potions at this point)
-	- Buy 1 X Speeds (3 if you have 0 Potions at this point)
+	- Buy 12 X Accuracy
+	- Buy 9 X Special
+	- Buy 1 X Speed
 
-Take the elevator and get HM02 (Fly)
+#### End of Shopping:
+- Take the elevator to 1F + exit the mart.
+- Bike West + cut the tree. 
+- Bike into the guard house and walk through it. 
+- Walk into the House and talk to the NPC.
+- Get HM02 (Fly) + exit the house.
 
-Menu after getting Fly:
-- Swap slot 2 with TM07
-- Use a Super Repel
-- Teach TM48 (Rock Slide) over Mega Punch (slot 1)
-- Swap slot 3 with X Accs
-- Teach HM02 to the bird
-- Use Fly to go to Lavender
+#### Fly Menu
+- Swap slot 2 Helix Fossil w/ TM07
+- d1 Use a Super Repel
+- d3 Teach TM48 (Rock Slide) over Mega Punch (slot 1)
+- Swap slot 3 S.S. Ticket w/ X Accuracy
+- d3 Teach HM02 to Bird
+- Fly (D3) to Lavender Town
+     - Walk East into the tower.
 
-## Lavender Town
+## Lavender Tower
 
-Note: From this point on you have 2 Revives which means deaths aren't as scary, so if you die remember to swap to a pokemon, Revive, let the swapped pokemon die and ANY AND ALL X ITEMS ARE GONE. This route has extras so you shouldn't run out of X items, and there will still be some saving since some deaths with Revives are still really slow to come back from if at all.
+- [Click here for Lavender Tower Movement Maps](https://imgur.com/a/J5e6jKB)
 
-**Rival:**
-- Pidgeotto:
-	- 1-8 Potion (X Acc if you get Sand-Attacked)
-	- TB
-- TB
-- BB
-- Thrash
+> You now have 2 Revives which means you can recover if Nido is KO'd.      
+> In general, if Nido is KO'd, then (1) swap to another pokemon, (2) use a revive on Nido       
+> (which leaves the cursor on Nido now!), (3) let the swapped pokemon be KO'd, and (4) send Nido back in.         
+> This route has extra X items so remember to re-use any required X items after reviving (if applicable)        
 
-[Tower Movement Map](https://imgur.com/gallery/Yf2tY3u)
+#### Lavender Rival:
+- Pidgeotto
+     - 1-8 HP: 
+          - Potion (or Super Potion to avoid using your last Potion)
+          - (+ X Accuracy, if hit by Sand Attack)
+          - TB
+     - 9+ HP: 
+          - TB
+- Gyarados
+     - TB
+- Growlithe
+     - (Potion or Super Potion if under 9 HP)
+     - BB
+- Kadabra
+     - Thrash x1
+- Ivysaur
+     - Thrash x2
 
 **Channeler 1:**
 - RS x2
 
-- Get the Elixers [here](http://gunnermaniac.com/pokeworld?map=145#12/10) and [here](http://gunnermaniac.com/pokeworld?map=146#4/12)
+#### Get both Elixers
+- First is a [visible item ball here](http://gunnermaniac.com/pokeworld?map=145#12/10) and [the other is hidden here](http://gunnermaniac.com/pokeworld?map=146#4/12)
+- Take the heal pad
 
 **Channeler 2:**
 - RS
@@ -448,294 +612,478 @@ Note: From this point on you have 2 Revives which means deaths aren't as scary, 
 **Channeler 3:**
 - RS
 
+Pick up the Rare Candy and walk down. 
 
-- Pick up the Rare Candy in your way
+#### Menu (a few tiles below picking up the candy):
 - Teach TM07 (Horn Drill) over Rock Slide (slot 1)
 
-**Ghost Encounter:**
-- Swap slot 3 with Super Repels
-- Use Poke Doll
+**Marowak Ghost Encounter:**
+- Swap slot 3 HM01 w/ Super Repel
+- d3 use Poke Doll
 
 **Rocket 1:**
 - TB x3 (+ BB)
 
 **Rocket 2:**
-- X Acc + HD x2
+- X Accuracy + HD x2
 
 **Rocket 3:**
 - TB x2
-- Thrash
+- Thrash x2-3
 
-Get the Poke Flute and Fly to Celadon City
+Talk to Mr. Fuji twice to get the Poke Flute
+- Exit the house and Fly (D1) to Celadon
 
 ## Celadon City
 
-- Use the center
-- Bike to Saffron City
+- **Use the Celadon Pokemon Center**
+     - ^this is essential to replenish PP + set our warp point. 
+- Exit the center and Bike East to Saffron City
+     - The guard will take your Fresh Water.
+- Enter Saffron City + get back on the bike. 
 
 ## Saffron City
 
-- Enter Silph Co and take the stairs to floor 5
-- Get the [hidden Elixer](http://gunnermaniac.com/pokeworld?map=210#12/3)
+- Bike into Silph Co. and take the stairs to Floor 5.
+- Get the [hidden tree Elixer](http://gunnermaniac.com/pokeworld?map=210#12/3)
+- <img src="https://pokemon-speedrunning.github.io/speedrun-routes/gen-1/images/classic/SilphCo1.png">
 
-**Rocket 1:**
-- Thrash
+**Rocket w/ Arbok:**
+- Thrash x2-3
+     - If paralyzed, just keep thrashing. 
 
-Get the Card Key
+> If under 90 HP + Paralyzed, then menu to use Parlyz Heal now.     
+> Otherwise, delay using a Parlyz Heal until you are in the next fight.     
 
-**Rival:**
-- Pidgeot:
-	- X Acc
-	- If you were paralyzed on Arbok, use a Parlyz Heal
-	- X Speed
-- HD x5
+Take the teleporter twice, get the Card Key, take the teleporter twice again. 
+- Open the door on the left and take the teleporter. 
+- Walk right + open the middle left door. 
+- Take the teleporter + walk Up + Left to have Silph Rival walk up to you.
+     - This results in fewer steps overall since rival exits screen quicker after the fight this way. 
 
-Note: In this split we want to take a bit of damage to do a strat on Koga called Boom Strats
+#### Silph Rival:
+- Pidgeot
+	- **X Accuracy**
+	- (+ Parlyz Heal, if needed) 
+	- **X Speed**
+        - HD x5
 
-If 1-77, use an Elixer before the next fight
+> Note: In this split we want to take a bit of damage to do a strat on Koga that we call "Boom Strats".        
+> Boom Strats --> intentionally being KO'd by Koga's Weezing (from Selfdestruct) to set up late-game red bar.       
 
-**Rocket 2:**
-- Cubone:
-	- X Acc
-	- If Cubone damages you below 78 and you haven't used Elixer, use it now
-	- BB
-- Drowzee:
-	- If you haven't used Elixer, use it now
-	- HD
-- Marowak: HD
+#### When to use Silph Elixer:
+- If under 78 HP, then menu after taking the teleporter pad + use Slot 8 **Elixer** before the next fight. 
+- If 78+ HP, then we delay using the Elixer - follow the Silph Rocket fight notes below. 
 
-**Giovanni:**
-- X Acc + HD
-- HD
-- BB
-- HD
+#### Silph Rocket:
+- Cubone
+	- **X Accuracy**
+	- if Bone Club hits, then use **Elixer** now (if you haven't already)
+	- **BB**
+- Drowzee
+	- If you haven't used **Elixer** yet, use it now.
+	- **HD**
+- Marowak
+        - **HD**
 
-Go back to the elevator and go to the 10th Floor to get [TM26 (Earthquake)](https://gunnermaniac.com/pokeworld?map=234#2/12) and the [Rare Candy](https://gunnermaniac.com/pokeworld?map=234#4/14)
+#### Silph Giovanni:
+- Nidorino: **X Accuracy** + HD
+- Kangaskhan: HD
+- Rhyhorn: **BB**
+- Nidoqueen: HD
 
-Use Dig on Paras
+Go back to the elevator and go to the 10th Floor to get [TM26 (Earthquake)](https://gunnermaniac.com/pokeworld?map=234#2/12) and a [Rare Candy](https://gunnermaniac.com/pokeworld?map=234#4/14)
+
+Dig out.
 
 ## Celadon City
 
-- Use your Bike and go to Snorlax
+- Bike west to Snorlax
 
-Menu before Snorlax:
-- Use a Repel
-- Swap slot 5 (Parlyz Heal) for Rare Candies
-- Use Poke Flute
+#### Snorlax Menu
+- Slot 4 - Repel
+- d1 swap Parlyz Heal w/ Rare Candy
+- d1 use Poke Flute
 
 ## Cycling Road
 
-- Note: You can hold B to stop automatically moving down on Cycling Road
+- Note: You can hold B (or A) to stop on Cycling Road (otherwise you move down automatically)
 - Get the [hidden Rare Candy](http://gunnermaniac.com/pokeworld?map=1#125/148)
+- <img src="https://pokemon-speedrunning.github.io/speedrun-routes/gen-1/images/classic/CyclingRoad.png" width="300">
+
 
 ## Fuschia City
 
-Menu:
-- Use a Repel
-- Swap slot 6 (Potion) with X Spec (if 0 Potions, then swap Helix Fossil with X Spec instead)
+- Exit Cycling Road, walk through the guard house, and menu when you exit.
+
+#### EQ Menu:
+- Slot 4 - Repel
+- d2 swap Potion w/ X Special
 - Teach TM26 (Earthquake) over Thrash (slot 2)
 - Use Bike
+
+> If zero potions left, then swap Helix Fossil with X Special instead. 
+
+- Cut both trees to enter Safari Zone
+- <img src="https://pokemon-speedrunning.github.io/speedrun-routes/gen-1/images/classic/CutBothTrees.png" width="350">
 
 [Safari Movement Map](https://imgur.com/gallery/h9KpU3I)
 
 In the Safari Zone:
-- Super Repel on the 2nd map around [this tile](https://gunnermaniac.com/pokeworld?map=217#13/24)
-- Pick up the [Teeth](https://gunnermaniac.com/pokeworld?map=219#19/7) and get Surf
-- After getting Surf, Dig out of the safari and Fly back to Fuschia City
+- Super Repel in Zone 2 around [this tile](https://gunnermaniac.com/pokeworld?map=217#13/24)
+- Pick up the [Gold Teeth](https://gunnermaniac.com/pokeworld?map=219#19/7)
+- Enter the Surf House and get HM03 (Surf)
+- Exit the Surf House
 
-**Juggler 1:**
+#### Menu (after exiting the house):
+- Use Dig
+- Fly (D2) back to Fuschia City
+- Walk West and enter Koga's Gym
+- <img src="https://i.imgur.com/pN22DR8.png" width="125">
+
+#### Juggler 1:
 - EQ x4
 
-**Juggler 2:**
+#### Juggler 2:
 - EQ
 - EQ + TB
-	- If TB gets disabled, finish with BB if it's in range, finish with EQ if not or you don't know the range
+     - If TB gets disabled, finish with BB if it's in range, finish with EQ if not or you don't know the range
 
-**Koga:**
+> Ideally we either get KO'd by Weezing's Selfdestruct or hit below 15 HP, in which case, play normally.      
+> If you lived with 15+ HP, still play normally for now...      
+> ... but note that there will be a simple backup strategy to stall on Erika for damage later.      
+
+#### Koga:
 - EQ x3
-- Elixer on Weezing
-	- If Koga used X Attack, scroll up 2 and use X Spec until you die
-	- If you didn't die from Koga you can still try to get red bar by following the [intermediate backups](https://docs.google.com/document/d/1_q5ddsyYnIKN48_UlokZw4mPmlMZLnTXDPihN_UQFwY/edit?usp=sharing). Note that this can be risky
+- Weezing: 
+     - Use Slot 8 **Elixer** 
+     - (+ u2 X Special, if Koga uses X-Attack)
+     - until Weezing uses Self Destruct
 
-Menu after Koga:
-- Use all Rare Candies
-- Bike to get Strength
+> Do not revive Nido! Do not heal Nido!         
+> We have purposely allowed Nido to be KO'd (or hit to low health)           
+> so that we can use Rare Candies to bring Nido into red bar for the Gym Rush.          
+
+#### Exit Koga's Gym.
+
+## Mansion
+
+#### Cany Menu (outside of Koga's Gym): 
+- Slot 5 - Use all Rare Candies on Nido
+- Bike East
+
+#### Hop the ledge + enter the Warden's House
+- Talk to the Warden to trade Gold Teeth for HM04.
+- Exit the Warden's house.
 - Fly to Pallet Town
 
-## Pallet Town
+> An NPC will walk in a random direction as you Fly in, possibly blocking your path. 
 
-Menu at the bottom of the water:
-- Super Repel
+Walk down + left to face the water in the bottom left of Pallet Town:
+- <img src="https://i.imgur.com/xEpkSOT.png" width="125">
+
+#### Surf Menu
+- Super Repel 
 - Teach HM03 (Surf) to Squirtle
 - Surf
+     - Surf straight down, move one tile left, continue straight down.
+     - The fisherman has zero vision, he won't see you. 
+- <img src="https://i.imgur.com/yiq3lzt.png">
 
-## Cinnabar Island
 
-- Pick up TM14 (Blizzard)
-- Menu:
-	- Teach HM04 (Strength) to Squirtle over Tackle (slot 1)
-	- Teach TM14 (Blizzard) over BB
-	- Use Repel (THIS IS THE **REPEL** NOT SUPER REPEL)
+#### Inside Mansion:
+
+- 1F: 
+     - Walk straight up + take the stairs.
+- 2F: 
+     - Walk right, up and around to the stairs in the room above you.
+     - <img src="https://i.imgur.com/Lprfchj.png">
+- 3F:
+     - Hit the switch and fall through the hole.
+     - <img src="https://i.imgur.com/6Ygm5Jr.png" width="200">
+- After falling (1F)
+     - Avoid the scientist, skip the item, take the stairs.
+     - <img src="https://i.imgur.com/jd5OoGs.png">
+- Last Floor (B1F):
+     - Pick up [TM14](https://www.extratricky.com/pokeworld/rb/216#19,25) (Blizzard) + **Menu immediately**
+     - (see map below the blizzard menu notes for item locations)
+
+#### Blizzard Menu:
+- Teach HM04 (Strength) to Squirtle over Tackle (slot 1)
+- Teach TM14 (Blizzard) to Nido over Bubblebeam (slot 4 - "down x3")
+- Use **Repel** - Slot 4 (this is the last **REPEL**, do NOT Super Repel)
+
+#### Last floor (B1F) Movement:
+- <img src="https://i.imgur.com/QrcOYpP.png">
+- Hit the switch after Blizzard Menu
+- Hit the next switch.
 - Pick up the [Rare Candy](http://gunnermaniac.com/pokeworld?map=216#10/2)
 - Pick up the [Secret Key](https://gunnermaniac.com/pokeworld?map=216#5/13)
 - Dig out
 
 ## Celadon City
 
-Bike to the gym
+Bike down to cut the tree blocking [the path to Erika's Gym](https://i.imgur.com/oJtdXdj.png). 
+- Enter the gym.  
+- <img src="https://i.imgur.com/cl4CRGn.png">
 
-**Beauty:**
-- Blizz
+#### Beauty's Exeggcute: **Blizz**
 
-**Erika:**
-- EQ
-- Blizz
-- EQ
+| HP after Exeggcute  | Overview of Backup Boom Strats for Erika                                                                                                        
+| ------------------- | --------------------------------------                                            
+| 1-24                | Play Normally --> **EQ, Blizz, EQ**
+| 25-32               | Poké Flute Stall on **Vileplume** until hit, then play normally                                                                          
+| 33+                 | Poké Flute Stall on **Victreebel** until hit, then play noramlly   
+|                     | if needed, Poké Flute is Slot 15 (2 below HM02) 
 
-Fly back to Cinnabar
+#### Erika:
+- Victreebel
+     - EQ
+- Tangela
+     - Blizz
+- Vileplume
+     - EQ
+
+Cut the middle tree, exit the gym, and Fly (D2) back to Cinnabar.
 
 ## Cinnabar Island
 
 Quiz answers: A B B B A B
 
-**Blaine:**
-- X Acc + EQ
-- HD x3
+> No need to toggle when you reach the yes/no text box.     
+> Pressing A will answer YES     
+> Pressing B will answer NO     
 
-Dig out and Bike to Sabrina's gym
+#### Blaine:
+- Growlithe
+     - X Accuracy
+     - EQ
+- Ponyta
+     - HD (use EQ if you accidentally use a HD on Growlithe)
+- Rapidash
+     - HD
+- Arcanine
+     - HD
+
+Dig out and Bike to Sabrina's gym.
+- Northeast corner of Saffron City
+- 1st gym is the fighting dojo, 2nd gym is the correct gym
 
 ## Saffron City
 
-Teleporter puzzle: Top left, Bottom left, Bottom left
+Take the only teleporter pad to enter the puzzle.
 
-**Sabrina:**
+> Avoid the trainers' lines of sight by hugging the bottom walls.
+
+#### Teleporter Puzzle Solution: 
+- Top Left, Bottom Left, Bottom Left
+- (or think: Diagonal, Diagonal, hold Down)
+
+#### Sabrina:
 - EQ x4
 
-Walk back to the teleporter and Dig out and Fly to
+Walk back to the teleporter, Dig out, Fly (U1) to Viridian City, and bike to Giovanni's Gym.
 
 ## Viridian City
 
-**Cooltrainer:**
+<img src="https://pokemon-speedrunning.github.io/speedrun-routes/gen-1/images/classic/Blackbelt.png" width="300">
+
+**Cooltrainer's Rhyhorn:**
 - EQ
 
-[OPTIONAL SAVE: This next fight has a decent chance to die, and reviving will lose red bar so saving is advised]
+#### Optional Save before Blackbelt
+- Blackbelt's Machoke has a decent chance to KO you and reviving will lose red bar so saving is advised.
 
-**Blackbelt:**
-- X Acc + HD
-- Blizz
-- HD
+#### Blackbelt:
+- Machoke
+     - **X Accuracy**
+     - HD
+- Machop
+     - Blizz (or EQ if somehow 0 Blizz are left)
+- Machoke
+     - HD
 
-Leave the gym to reset the trainer
+Leave the gym and immediately reenter to reset the trainer.
 
-Menu after entering the gym again:
-- Elixer
+#### Menu one step up after reentering the gym again:
+- Slot 6 - Elixer
 
 **Giovanni:**
 - EQ x4
-- Blizz (+ Blizz)
+- Rhydon: Blizz (+ Blizz)
 	- Note: Don't go below 2 Blizzards in this fight, use EQ to finish Rhydon if you need to
 
-Menu after leaving the gym:
+> The notes below assume optimal Super Repel locations         
+
+Menu after leaving the gym (+ hopping the ledge):
 - Super Repel
 - Bike
 
-**Rival:**
-- X Acc + Blizz + TB
-- HD x2
-- X Spec (on Growlithe)
-- HD x3
-	- Note: Only if you had 0 Potions in Celadon and bought 3 X Speeds do the following instead:
-	- X Acc + X Speed + Blizz (+ TB), HD x5
-	- Otherwise, the badge boost from the X Spec on Growlithe allows us to outspeed Alakazam.
+> remember to X Special **on Growlithe** in the next fight     
+> the badge boost is required there to outspeed Zam     
+
+**Viridian Rival:**
+- Pidgeot
+     - **X Accuracy**
+     - Blizz + TB
+- Rhyhorn
+     - HD
+- Gyarados
+     - HD
+- Growlithe
+     - **X Special**
+     - HD
+- Alakazam
+     - HD
+- Venusaur
+     - HD
+
+## Badge Check
+
+- Exit the house and Bike. Continue north towards Victory Road. 
+- Menu to enter the water:
+     - Up 1 to Pkmn, D1 to Squirtle, D1 to Surf. 
+- Pick up the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=34#8/90) from the water.
+- Menu after exiting the water:
+     - Super Repel
+     - Bike
 
 ## Victory Road
 
-[Super Repel locations](https://imgur.com/gallery/laeW1PT) and [Victory Road map](https://imgur.com/gallery/vKQYRQZ)
+<img src="https://i.imgur.com/ys46wMK.png">
 
-- Pick up the [hidden Max Ether](https://gunnermaniac.com/pokeworld?map=34#8/90) from the water
-- Use a Super Repel one step into the cave
-- Watch a top leaderboard run for how to do the Strength boulder puzzles
-- Use the 2nd Super Repel on [this tile](https://gunnermaniac.com/pokeworld?map=194#5/14) before using Strength
-- After dropping before the last boulder on [this tile](https://gunnermaniac.com/pokeworld?map=194#24/16):
-	- Use Strength
-	- Use a Max Ether on HD
-	- Super Repel
-	- Bike
-- Optional Safety: Pick up the [Full Restore](http://gunnermaniac.com/pokeworld?map=194#26/7)
+#### Menu one step up into cave - "Boulder #1"
+- Use Strength
 
-## E4
+#### Menu to the right of Boulder #2
+- Use Super Repel
+- Use Strength
 
-Don't deposit extra pokes unless you have no more Revives
+#### Menu beneath Boulder #3
+- Use Strength
 
-**Lorelei:**
+> If your repel runs out early, perform the last menu early (don't yolo tiles)
+
+#### Last Menu *after dropping through the hole* - "Boulder #4"
+- Use Strength
+- d2 **Max Ether** on (u1) Nido on Slot 1 (HD)
+- u2 Super Repel
+- Bike
+
+#### Optional (recommended if low on healing items)
+- Pick up the [hidden Full Restore](http://gunnermaniac.com/pokeworld?map=194#26/7) at the end of Victory Road.
+
+## Elite Four
+
+> If you have zero Revives left, deposit Squirtle + Paras; otherwise don't deposit.            
+> Note: if you accidentally let bird be KO'd already, swap to Paras on Lorelei instead of bird for the Trainer AI manip to still work.     
+
+#### Lorelei
 - Dewgong:
-	- Swap to the bird turn 1
-	- Swap back to Nido and X Acc
-	- HD x5
+     - Swap to Bird turn 1 (Dewgong uses Aurora Beam turn 1 on bird)
+     - Swap back to Nido + **Use X Accuracy** (Dewgong uses Rest turn 2)
+- **HD x5**
 
-Before Bruno use a Max Ether on HD
+#### Menu before Bruno
+- Use Max Ether on HD
 
-**Bruno:**
-- X Acc + HD x5
+> Bruno's Onix is unlikely to KO you, but if Onix does manage to KO you with a Slam crit, then       
+> Send out Squirtle/Paras, Revive Nido, swap back to Nido immediately, X Accuracy + HD x5       
+> (no need to let the swapped poke be KO'd here - splitting EXP is okay in this instance)        
 
-Menu before Agatha:
-- 1-18 Super Potion + Potion
-- 19+ Super Potion
-	- If out of Potion, just Super Potion once
-- Rare Candy
+#### Bruno:
+- X Accuracy + HD x5
 
-**Agatha:**
-- Gengar: X Spec + EQ
-	- If you get put to sleep use the Poke Flute, and if you get confused risk it since you would need to X Spec again if you swapped
-- Golbat: Blizz
-	- If you miss Blizz, and Golbat uses Haze, use
-		- 2x TB on Golbat
-		- Consider using a Super Potion on Arbok at 25-60 (or use X Speed if you bought 3)
-		- 25 HP and lower has red bar, and is usually worth taking the risk
-		- You are slower than the last Gengar, so it will have a turn to use a move on you
-	- If you miss Blizz, but Golbat doesn't use Haze, use Blizz again, or TB if out of Blizzards
-- EQ x3
+#### Menu before Agatha:
+- Heal to 122+ HP
+- Super Potion x1-2 (+ Potion)
+- Use Rare Candy on Nido (2 below HM03)
+
+#### Agatha:
+- 1st Gengar: 
+     - **X Special**
+          - If Hypnosis hits, use the Poke Flute (2 below HM02)
+          - If confused, do NOT swap (it is not worth having to re-setup the X Special).
+               - Yolo through confusion by continuing to attempt to get your moves off.
+               - Under 57 HP, use Full Restore, but note that this does not remove confusion.
+     - **EQ**
+- Golbat: 
+     - **Blizz** 
+     - Or **TB x2** if zero Blizz left
+     - If Blizz miss into Golbat using **HAZE** note the following:
+          - HAZE --> Use **TB x2** on Golbat (since Blizz no longer OHKOs)
+          - HAZE --> Agatha's last Pokemon (her 2nd Gengar) will outspeed us and can deal up to 60 damage. 
+          - HAZE + 0 Revives + under 61 HP ---> Full Restore (+ Para Heal if Glared) **on Arbok**; otherwise, yolo
+- Haunter:
+     - EQ
+- Arbok:
+     - EQ
+- 2nd Gengar:
+     - EQ
+
+HP      | Healing Strategy before Lance
+------- | ---------------------------
+4-7     | Super Potion x2 + Potion x2
+8-27    | Super Potion x2 + Potion
+28-48   | Super Potion x2
+49-57   | Super Potion + Potion x2
+58-77   | Super Potion + Potion
+78-98   | Super Potion
+99-106  | Potion x2
+107-127 | Potion
+<img src="https://i.imgur.com/QfIueNL.png" height="200" >
 
 Menu before Lance:
-- Use Elixer
-- Heal using the chart below
-- [OPTIONAL SAVE: Lance is somewhat likely to kill you, so saving is recommended]
+- **Use Elixer**
+- **Heal to 128+ HP**
+- Save the game: Lance is somewhat likely to KO you, so saving is recommended.
 
-HP      | ITEMS
-------- | ---------------------------
-4-6     | Super Potion x2 + Potion x2
-8-26    | Super Potion x2 + Potion
-27-48   | Super Potion x2
-49-56   | Super Potion + Potion x2
-57-76   | Super Potion + Potion
-77-98   | Super Potion
-99-106  | Potion x2
-107-126 | Potion
+> Note: the X Special on **Dragonair** --> Speed Badge Boost required to outspeed Aerodactyl
 
-If you don't have enough Potions, use the next healing option
-- Feel free to use your Full Restore if you picked it up and you want to play really safe
+#### Lance:
+- Gyarados: 
+     - **X Special**
+     - TB
+- Dragonair 1: 
+     - **X Special**
+     - (+ X Accuracy, only if you have 3 X Accuracy left)
+     - Blizz
+- Dragonair 2: 
+     - Blizz
+- Aerodactyl: 
+     - TB
+- Dragonite: 
+     - Blizz
 
-**Lance:**
-- Gyarados: X Spec + TB
-- Dragonair 1: Blizz
-- Dragonair 2: X Spec + Blizz (use X Speed instead if you have one)
-- Aero: TB
-- Dragonite: Blizz
+#### Menu After Lance (before entering the next room):
+- Heal to 45+ HP 
+     - (or to 22+ if you need red bar to PB)
+- Optional: Save the game 
+     - (especially if you don't have an extra X Accuracy + X Special + Revive + alive Squirtle or Paras to sac)
 
-After Lance:
-- Heal to 22+
-- [OPTIONAL SAVE: Saving for Champ can be good if you don't have a spare X Accuracy + X Special + Revive]
+> Animations are automatically turned on when you enter the Champ fight       
+> In red bar, it's faster to HD Rhydon and TB Gyarados      
+> Not in red bar, it's faster to Blizz Rhydon and HD Gyarados      
+> Either strategy is fine, just ensure that you have HDs left to KO Arcanine & Venusaur     
 
-**Champion:**
-- Pidgeot: X Spec
+#### Champion:
+- Pidgeot Turn 1: **X Special**
+- Pidgeot Turn 2: 
 	- If Pidgeot does NOT use Sky Attack turn 1:
-		- Pidgeot: X Acc + HD
+		- Pidgeot: **X Accuracy** + HD
 		- Alakazam: HD
-		- Rhydon: HD
-		- Gyarados: **TB**
+		- Rhydon: **Blizz** (or **HD** if in red bar or 0 Blizz left)
+		- Gyarados: **HD** (must **TB** Gyarados if we used HD on Rhydon)
 		- Arcanine: HD
 		- Venusaur: HD
 	- If Pidgeot begins to use Sky Attack turn 1 (*Pidgeot is glowing*):
 		- Pidgeot: **Blizz**
 		- Alakazam: **EQ**
-		- Rhydon: X Acc + HD x4
+		- Rhydon: **X Accuracy** + HD x4
+
+## Hall of Fame
+
+Clear all of Oak's text.
+- Your Pokemon are registered in the HoF and the in game time is shown.
+- Clear the final two text boxes after IGT is shown and the timing ends when the screen fully fades to white before the credits.
+- Note that the game will not fully save until "THE END" appears on screen at the end of the credits.

--- a/docs/gen-1/red-blue/main-glitchless/classic-advanced-route/README.md
+++ b/docs/gen-1/red-blue/main-glitchless/classic-advanced-route/README.md
@@ -572,7 +572,7 @@ Silph Rocket #2:
 - Drowzee: HD
 - Marowak: IB
 
-<img src="gen-1/images/classic/EQMenuCandyGuide.png">         
+<img src="https://i.imgur.com/HibE7M2.png">         
 
 	
 - Use the chart to determine how many rare candies you can later use.
@@ -633,7 +633,7 @@ Safari Menu (2-3 Carbos + good HP):
 - Down 1 PPUP
 - Bike
 
-Safari Menu (2 Carbos + bad HP / already tossed Parlyz Heal)
+Safari Menu (if Parlyz Heal was Tossed)
 - Slot 3 Super Repel
 - Down 1 Rare Candy x1-2
 - Down 3 swap Potion w/ TM26
@@ -644,7 +644,8 @@ Safari Menu (2 Carbos + bad HP / already tossed Parlyz Heal)
      
 Menu in Zone 3
 - Slot 3 Super Repel
-- Down 2 TM26 Earthquake over slot 2 Rock Slide
+- Down X, teach TM26 Earthquake over slot 2 Rock Slide
+     - D1, D2, or D4, depending on TM26 item location
 
 Get the Gold Teeth, get HM03, and exit the house.
 - Use Dig.


### PR DESCRIPTION
Archived the old versions of both lass & no-lass. 
Added embedded images and overhauled each route (w/out making any actual route changes). 
Included a link to my own Lorelei segment (yt - unlisted) as a reference for how to do VR. Includes both the cautious sort-of 2 Srepel strategy & the optimal Srepel locations, which is still the default strategy for this route. 
- Also made a quick fix on the Classic Advanced Route Carbos Stacking strats. 